### PR TITLE
perf: Skip session fetch when session is newly created locally

### DIFF
--- a/src/components/v2/GeminiLayout.tsx
+++ b/src/components/v2/GeminiLayout.tsx
@@ -47,6 +47,14 @@ export function GeminiLayout({ sessionId }: GeminiLayoutProps) {
         return
       }
 
+      // Se o sessionId da URL é igual ao do store mas ainda não há mensagens,
+      // significa que acabamos de criar essa sessão localmente (UUID gerado no handleSendMessage)
+      // Não precisa buscar do backend pois a sessão ainda não existe lá
+      if (sessionId === currentSessionId && messages.length === 0) {
+        setIsLoadingSession(false)
+        return
+      }
+
       // Se agentId ainda não está disponível, aguardar
       if (!agentId || agentId === 'no-agents') {
         setIsLoadingSession(true)


### PR DESCRIPTION
## Problem
When a new chat is created and a UUID is generated on the frontend, the app was making an unnecessary API call to fetch that session from the backend, which would fail since the session doesn't exist yet.

## Solution
Added a check in the session loading logic to skip the backend fetch when:
- The sessionId in the URL matches the sessionId in the store
- There are no messages yet

This indicates the session was just created locally and hasn't been saved to the backend yet.

## Impact
- Reduces unnecessary API calls on new chat creation
- Improves initial chat experience performance
- Prevents console errors from failed session fetches

## Testing
- ✅ Build passes
- Manual testing needed: create new chat and verify no session fetch is attempted