### PR TITLE
fix: align frontend API proxies with backend contracts

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -26,7 +26,20 @@ export async function POST(request: NextRequest) {
     // Get the response data
     const data = await response.json()
 
-    // Return the response with the same status code
+    // Map backend response to frontend expected format
+    // Backend returns: { access_token, token_type }
+    // Frontend expects: { token }
+    if (response.ok && data.access_token) {
+      return NextResponse.json(
+        {
+          ...data,
+          token: data.access_token
+        },
+        { status: response.status }
+      )
+    }
+
+    // Return error response as-is
     return NextResponse.json(data, { status: response.status })
   } catch {
     return NextResponse.json(

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -32,7 +32,22 @@ export async function GET(request: NextRequest) {
     // Get the response data
     const data = await response.json()
 
-    // Return the response with the same status code
+    // Map backend response to frontend expected format
+    // Backend returns: { id, email, full_name, is_active, is_superuser, created_at, organization_id }
+    // Frontend expects: { id, email, name, role }
+    if (response.ok) {
+      return NextResponse.json(
+        {
+          id: data.id,
+          email: data.email,
+          name: data.full_name || '',
+          role: data.is_superuser ? 'admin' : 'user'
+        },
+        { status: response.status }
+      )
+    }
+
+    // Return error response as-is
     return NextResponse.json(data, { status: response.status })
   } catch {
     return NextResponse.json(

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -14,19 +14,41 @@ export async function POST(request: NextRequest) {
     // Parse the request body (JSON for register)
     const body = await request.json()
 
+    // Map frontend request to backend expected format
+    // Frontend sends: { email, password, name, inviteToken? }
+    // Backend expects: { email, password, full_name }
+    const backendBody = {
+      email: body.email,
+      password: body.password,
+      full_name: body.name || body.full_name || ''
+    }
+
     // Forward the request to the backend
     const response = await fetch(`${BACKEND_URL}/api/v1/auth/register`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify(body)
+      body: JSON.stringify(backendBody)
     })
 
     // Get the response data
     const data = await response.json()
 
-    // Return the response with the same status code
+    // Map backend response to frontend expected format
+    // Backend returns: { access_token, token_type }
+    // Frontend expects: { token }
+    if (response.ok && data.access_token) {
+      return NextResponse.json(
+        {
+          ...data,
+          token: data.access_token
+        },
+        { status: response.status }
+      )
+    }
+
+    // Return error response as-is
     return NextResponse.json(data, { status: response.status })
   } catch {
     return NextResponse.json(

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -13,12 +13,20 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
 
+    // Map frontend request to backend expected format
+    // Frontend sends: { token, password }
+    // Backend expects: { token, new_password }
+    const backendBody = {
+      token: body.token,
+      new_password: body.password || body.new_password
+    }
+
     const response = await fetch(`${BACKEND_URL}/api/v1/auth/reset-password`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify(body)
+      body: JSON.stringify(backendBody)
     })
 
     const data = await response.json()

--- a/src/lib/auth/api.ts
+++ b/src/lib/auth/api.ts
@@ -25,12 +25,12 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '/api'
 
 const AUTH_ENDPOINTS = {
   LOGIN: '/auth/login',
-  SIGNUP: '/auth/signup',
+  SIGNUP: '/auth/register',
   LOGOUT: '/auth/logout',
   REFRESH: '/auth/refresh',
   VALIDATE_INVITE: '/auth/invite/validate',
-  PASSWORD_RESET_REQUEST: '/auth/password/reset-request',
-  PASSWORD_RESET: '/auth/password/reset'
+  PASSWORD_RESET_REQUEST: '/auth/forgot-password',
+  PASSWORD_RESET: '/auth/reset-password'
 } as const
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Map `access_token` → `token` in login and register responses
- Map `name` → `full_name` in register request body  
- Map `full_name` → `name` and derive `role` from `is_superuser` in `/auth/me`
- Map `password` → `new_password` in reset-password request
- Fix `AUTH_ENDPOINTS`: `SIGNUP` → `/auth/register`, password reset paths corrected

## Context

These changes fix critical incompatibilities between the frontend API proxies and the backend contracts, ensuring the application works correctly in production.

## Test plan

- [ ] Test user registration (name should be saved correctly)
- [ ] Test login (should receive token and authenticate)
- [ ] Test GET /auth/me (should return name and role)
- [ ] Test password reset flow
- [ ] Verify build passes