### PR TITLE
fix: add authentication token to document upload

### DIFF
--- a/src/app/api/documents/upload/route.ts
+++ b/src/app/api/documents/upload/route.ts
@@ -10,8 +10,7 @@
  * - `POST ${BACKEND_URL}/api/v1/documents/upload`
  *
  * Auth:
- * - Atualmente não exige token no backend, mas este proxy existe para padronizar
- *   o contrato e evitar CORS.
+ * - Obrigatório: `Authorization: Bearer <token>`
  *
  * Chamadores:
  * - `src/hooks/useChatFiles.ts`, `src/components/v2/FileUpload/FileUploadModal.tsx`
@@ -23,6 +22,16 @@ const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
 
 export async function POST(request: NextRequest) {
   try {
+    // Get the Authorization header from the request
+    const authorization = request.headers.get('authorization')
+
+    if (!authorization) {
+      return NextResponse.json(
+        { detail: 'Authorization header required' },
+        { status: 401 }
+      )
+    }
+
     console.log(
       '[API Proxy] POST /api/documents/upload - Uploading file to backend'
     )
@@ -32,9 +41,12 @@ export async function POST(request: NextRequest) {
 
     console.log('[API Proxy] FormData fields:', Array.from(formData.keys()))
 
-    // Forward to backend
+    // Forward to backend with Authorization header
     const response = await fetch(`${BACKEND_URL}/api/v1/documents/upload`, {
       method: 'POST',
+      headers: {
+        Authorization: authorization
+      },
       body: formData
       // Don't set Content-Type header - let the browser set it with boundary
     })

--- a/src/components/v2/FileUpload/FileUploadModal.tsx
+++ b/src/components/v2/FileUpload/FileUploadModal.tsx
@@ -9,6 +9,7 @@ import {
   CheckCircle,
   AlertCircle
 } from 'lucide-react'
+import { getAuthToken } from '@/lib/auth/cookies'
 
 interface FileUploadModalProps {
   isOpen: boolean
@@ -138,8 +139,15 @@ export function FileUploadModal({
           '/api/documents/upload'
         )
 
+        const token = getAuthToken()
+        const headers: HeadersInit = {}
+        if (token) {
+          headers['Authorization'] = `Bearer ${token}`
+        }
+
         const response = await fetch('/api/documents/upload', {
           method: 'POST',
+          headers,
           body: formData
         })
 


### PR DESCRIPTION
## Summary
- Add Authorization header validation to `/api/documents/upload` BFF route
- Forward Authorization header to backend
- Add `getAuthToken()` to `FileUploadModal` and include token in upload request

## Test plan
- [ ] Test file upload with authenticated user
- [ ] Verify 401 error is returned when no token is provided
- [ ] Verify upload works correctly when token is provided

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)