### PR TITLE
fix: add authentication token to useDocuments hook and BFF routes

### DIFF
--- a/src/app/api/documents/[documentId]/download/route.ts
+++ b/src/app/api/documents/[documentId]/download/route.ts
@@ -10,7 +10,7 @@
  * - `GET ${BACKEND_URL}/api/v1/documents/{documentId}/download`
  *
  * Auth:
- * - Atualmente não exige token no backend (mas pode ser endurecido no futuro).
+ * - Obrigatório: `Authorization: Bearer <token>`
  *
  * Chamadores:
  * - `src/hooks/useChatFiles.ts`, `src/hooks/useDocuments.ts`
@@ -25,6 +25,15 @@ export async function GET(
   { params }: { params: Promise<{ documentId: string }> }
 ) {
   try {
+    const authorization = request.headers.get('authorization')
+
+    if (!authorization) {
+      return NextResponse.json(
+        { detail: 'Authorization header required' },
+        { status: 401 }
+      )
+    }
+
     const { documentId } = await params
     const url = `${BACKEND_URL}/api/v1/documents/${documentId}/download`
 
@@ -32,7 +41,9 @@ export async function GET(
 
     const response = await fetch(url, {
       method: 'GET',
-      credentials: 'include'
+      headers: {
+        Authorization: authorization
+      }
     })
 
     console.log('[API Proxy] Download response status:', response.status)

--- a/src/app/api/documents/[documentId]/route.ts
+++ b/src/app/api/documents/[documentId]/route.ts
@@ -10,7 +10,7 @@
  * - `DELETE ${BACKEND_URL}/api/v1/documents/{documentId}`
  *
  * Auth:
- * - Atualmente não exige token no backend (mas pode ser endurecido no futuro).
+ * - Obrigatório: `Authorization: Bearer <token>`
  *
  * Chamadores:
  * - `src/hooks/useChatFiles.ts`, `src/hooks/useDocuments.ts`
@@ -25,6 +25,15 @@ export async function DELETE(
   { params }: { params: Promise<{ documentId: string }> }
 ) {
   try {
+    const authorization = request.headers.get('authorization')
+
+    if (!authorization) {
+      return NextResponse.json(
+        { detail: 'Authorization header required' },
+        { status: 401 }
+      )
+    }
+
     const { documentId } = await params
     const url = `${BACKEND_URL}/api/v1/documents/${documentId}`
 
@@ -32,7 +41,9 @@ export async function DELETE(
 
     const response = await fetch(url, {
       method: 'DELETE',
-      credentials: 'include'
+      headers: {
+        Authorization: authorization
+      }
     })
 
     console.log('[API Proxy] Delete response status:', response.status)

--- a/src/app/api/documents/user/[userId]/route.ts
+++ b/src/app/api/documents/user/[userId]/route.ts
@@ -10,7 +10,7 @@
  * - `GET ${BACKEND_URL}/api/v1/documents/user/{userId}?session_id=...`
  *
  * Auth:
- * - Atualmente não exige token no backend (mas pode ser endurecido no futuro).
+ * - Obrigatório: `Authorization: Bearer <token>`
  *
  * Response esperado (backend):
  * - `{ documents: [...], count: number }`
@@ -28,6 +28,16 @@ export async function GET(
   { params }: { params: Promise<{ userId: string }> }
 ) {
   try {
+    // Get the Authorization header from the request
+    const authorization = request.headers.get('authorization')
+
+    if (!authorization) {
+      return NextResponse.json(
+        { detail: 'Authorization header required' },
+        { status: 401 }
+      )
+    }
+
     const { userId } = await params
     const { searchParams } = new URL(request.url)
     const sessionId = searchParams.get('session_id')
@@ -39,7 +49,9 @@ export async function GET(
 
     const response = await fetch(backendUrl.toString(), {
       method: 'GET',
-      credentials: 'include'
+      headers: {
+        Authorization: authorization
+      }
     })
 
     console.log('[API Proxy] Documents response status:', response.status)

--- a/src/hooks/useDocuments.ts
+++ b/src/hooks/useDocuments.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import type { UserDocument } from '@/components/v2/FileUpload/FileList'
+import { getAuthToken } from '@/lib/auth/cookies'
 
 export function useDocuments(userId: string, sessionId?: string) {
   const [documents, setDocuments] = useState<UserDocument[]>([])
@@ -24,7 +25,13 @@ export function useDocuments(userId: string, sessionId?: string) {
 
       console.log('[useDocuments] Fetching documents from:', url.toString())
 
-      const response = await fetch(url.toString())
+      const token = getAuthToken()
+      const headers: HeadersInit = {}
+      if (token) {
+        headers['Authorization'] = `Bearer ${token}`
+      }
+
+      const response = await fetch(url.toString(), { headers })
 
       console.log('[useDocuments] Response status:', response.status)
 
@@ -54,8 +61,15 @@ export function useDocuments(userId: string, sessionId?: string) {
       // Use Next.js API Route as proxy to avoid CORS issues
       console.log('[useDocuments] Deleting document:', documentId)
 
+      const token = getAuthToken()
+      const headers: HeadersInit = {}
+      if (token) {
+        headers['Authorization'] = `Bearer ${token}`
+      }
+
       const response = await fetch(`/api/documents/${documentId}`, {
-        method: 'DELETE'
+        method: 'DELETE',
+        headers
       })
 
       console.log('[useDocuments] Delete response status:', response.status)
@@ -77,7 +91,15 @@ export function useDocuments(userId: string, sessionId?: string) {
       // Use Next.js API Route as proxy to avoid CORS issues
       console.log('[useDocuments] Downloading document:', documentId)
 
-      const response = await fetch(`/api/documents/${documentId}/download`)
+      const token = getAuthToken()
+      const headers: HeadersInit = {}
+      if (token) {
+        headers['Authorization'] = `Bearer ${token}`
+      }
+
+      const response = await fetch(`/api/documents/${documentId}/download`, {
+        headers
+      })
 
       console.log('[useDocuments] Download response status:', response.status)
 


### PR DESCRIPTION
## Summary
- Add `getAuthToken()` import to `useDocuments` hook
- Add Authorization header to `fetchDocuments`, `removeDocument`, and `downloadDocument` functions
- Add Authorization header validation and forwarding to BFF routes:
  - `/api/documents/user/[userId]` (GET)
  - `/api/documents/[documentId]` (DELETE)
  - `/api/documents/[documentId]/download` (GET)

## Test plan
- [ ] Test fetching documents for authenticated user
- [ ] Test deleting document with authenticated user
- [ ] Test downloading document with authenticated user
- [ ] Verify 401 error is returned when no token is provided

Closes #80