### PR TITLE
feat(auth): Add refresh token support

### DIFF
--- a/src/lib/auth/cookies.ts
+++ b/src/lib/auth/cookies.ts
@@ -13,6 +13,7 @@
 import Cookies from 'js-cookie'
 
 const TOKEN_COOKIE = 'auth_token'
+const REFRESH_TOKEN_COOKIE = 'refresh_token'
 
 /**
  * Opções de configuração dos cookies
@@ -59,4 +60,44 @@ export const removeAuthToken = (): void => {
  */
 export const hasAuthToken = (): boolean => {
   return !!getAuthToken()
+}
+
+// ============================================================================
+// Refresh Token Management
+// ============================================================================
+
+/**
+ * Salva o refresh token em um cookie seguro
+ *
+ * @param token - JWT refresh token
+ */
+export const setRefreshToken = (token: string): void => {
+  Cookies.set(REFRESH_TOKEN_COOKIE, token, {
+    ...COOKIE_OPTIONS,
+    expires: 7 // Refresh token válido por 7 dias
+  })
+}
+
+/**
+ * Recupera o refresh token do cookie
+ *
+ * @returns Refresh token ou undefined se não existir
+ */
+export const getRefreshToken = (): string | undefined => {
+  return Cookies.get(REFRESH_TOKEN_COOKIE)
+}
+
+/**
+ * Remove o refresh token (logout)
+ */
+export const removeRefreshToken = (): void => {
+  Cookies.remove(REFRESH_TOKEN_COOKIE, { path: '/' })
+}
+
+/**
+ * Remove ambos os tokens (logout completo)
+ */
+export const clearAllTokens = (): void => {
+  removeAuthToken()
+  removeRefreshToken()
 }

--- a/src/lib/auth/token-refresh.ts
+++ b/src/lib/auth/token-refresh.ts
@@ -1,0 +1,146 @@
+'use client'
+
+/**
+ * Token Refresh Utility
+ *
+ * Provides automatic token refresh functionality for the authentication system.
+ * Intercepts 401 responses and attempts to refresh the token before retrying.
+ */
+
+import {
+  getAuthToken,
+  setAuthToken,
+  getRefreshToken,
+  setRefreshToken,
+  removeAuthToken,
+  removeRefreshToken
+} from './cookies'
+
+const API_BASE = '/api/auth'
+
+interface RefreshResponse {
+  access_token: string
+  refresh_token: string
+  token_type: string
+}
+
+/**
+ * Attempt to refresh the access token using the refresh token.
+ * @returns New tokens or null if refresh failed
+ */
+export async function refreshTokens(): Promise<RefreshResponse | null> {
+  const refreshToken = getRefreshToken()
+
+  if (!refreshToken) {
+    console.log('[TokenRefresh] No refresh token available')
+    return null
+  }
+
+  try {
+    console.log('[TokenRefresh] Attempting token refresh...')
+
+    const response = await fetch(`${API_BASE}/refresh`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ refresh_token: refreshToken })
+    })
+
+    if (!response.ok) {
+      console.error('[TokenRefresh] Refresh failed:', response.status)
+      // Clear tokens on refresh failure
+      removeAuthToken()
+      removeRefreshToken()
+      return null
+    }
+
+    const data: RefreshResponse = await response.json()
+
+    // Store new tokens
+    setAuthToken(data.access_token)
+    if (data.refresh_token) {
+      setRefreshToken(data.refresh_token)
+    }
+
+    console.log('[TokenRefresh] Token refreshed successfully')
+    return data
+  } catch (error) {
+    console.error('[TokenRefresh] Error during refresh:', error)
+    removeAuthToken()
+    removeRefreshToken()
+    return null
+  }
+}
+
+/**
+ * Wrapper for fetch that automatically handles token refresh on 401.
+ * Use this instead of fetch for authenticated requests.
+ */
+export async function fetchWithRefresh(
+  url: string,
+  options: RequestInit = {}
+): Promise<Response> {
+  // Add auth header if we have a token
+  const token = getAuthToken()
+  if (token) {
+    options.headers = {
+      ...options.headers,
+      Authorization: `Bearer ${token}`
+    }
+  }
+
+  let response = await fetch(url, options)
+
+  // If unauthorized, try to refresh token and retry
+  if (response.status === 401) {
+    console.log('[TokenRefresh] Got 401, attempting refresh...')
+
+    const newTokens = await refreshTokens()
+
+    if (newTokens) {
+      // Retry with new token
+      options.headers = {
+        ...options.headers,
+        Authorization: `Bearer ${newTokens.access_token}`
+      }
+
+      response = await fetch(url, options)
+      console.log('[TokenRefresh] Retry response:', response.status)
+    }
+  }
+
+  return response
+}
+
+/**
+ * Check if token is about to expire and proactively refresh.
+ * Call this periodically (e.g., every 5 minutes) to maintain session.
+ */
+export function scheduleTokenRefresh(
+  intervalMs: number = 5 * 60 * 1000
+): () => void {
+  const intervalId = setInterval(async () => {
+    const token = getAuthToken()
+    if (!token) return
+
+    // Decode token to check expiration (simple base64 decode)
+    try {
+      const payload = JSON.parse(atob(token.split('.')[1]))
+      const expiresAt = payload.exp * 1000
+      const now = Date.now()
+      const timeUntilExpiry = expiresAt - now
+
+      // Refresh if less than 2 minutes until expiry
+      if (timeUntilExpiry < 2 * 60 * 1000) {
+        console.log('[TokenRefresh] Token expiring soon, proactive refresh')
+        await refreshTokens()
+      }
+    } catch {
+      // Token decode failed, ignore
+    }
+  }, intervalMs)
+
+  // Return cleanup function
+  return () => clearInterval(intervalId)
+}


### PR DESCRIPTION
## Descrição
Adiciona suporte a refresh token no frontend.

## Mudanças
- `cookies.ts`: Adicionado `setRefreshToken`, `getRefreshToken`, `removeRefreshToken`, `clearAllTokens`
- `token-refresh.ts` (novo): 
  - `refreshTokens()` - renova tokens via API
  - `fetchWithRefresh()` - wrapper de fetch com retry em 401
  - `scheduleTokenRefresh()` - renovação proativa

Relacionado ao backend PR #39