### PR TITLE
feat(sentry): configure source maps upload for production (#142)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,13 @@ RESEND_FROM_EMAIL=noreply@verityagro.com.br
 
 # Sentry - Monitoramento de erros
 # SENTRY_DSN=https://xxxx@xxx.ingest.sentry.io/xxxx
+# NEXT_PUBLIC_SENTRY_DSN=https://xxxx@xxx.ingest.sentry.io/xxxx
+
+# Sentry - Source Maps Upload (obrigatorio para producao)
+# Obtenha em: https://sentry.io/settings/auth-tokens/
+# Scopes necessarios: project:read, project:releases, org:read
+# SENTRY_ORG=seu-org-slug
+# SENTRY_PROJECT=seu-project-slug
 # SENTRY_AUTH_TOKEN=sntrys_xxxxxxxx
 
 # PostHog - Analytics

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from 'next'
 import withPWA from '@ducanh2912/next-pwa'
+import { withSentryConfig } from '@sentry/nextjs'
 
 const nextConfig: NextConfig = {
   devIndicators: false,
@@ -152,4 +153,25 @@ const pwaConfig = withPWA({
   }
 })
 
-export default pwaConfig(nextConfig)
+// Sentry configuration for source maps upload
+const sentryOptions = {
+  // Organization and project slugs from Sentry
+  org: process.env.SENTRY_ORG,
+  project: process.env.SENTRY_PROJECT,
+
+  // Auth token for uploading source maps
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+
+  // Suppress logs unless in CI
+  silent: !process.env.CI,
+
+  // Hide source maps from browser devtools in production
+  hideSourceMaps: true,
+
+  // Bundle size optimizations
+  bundleSizeOptimizations: {
+    excludeDebugStatements: true
+  }
+}
+
+export default withSentryConfig(pwaConfig(nextConfig), sentryOptions)


### PR DESCRIPTION
## Summary
- Add `withSentryConfig` wrapper to `next.config.ts` for automatic source maps upload
- Document `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN` environment variables in `.env.example`
- Hide source maps from browser devtools in production for security
- Enable bundle size optimizations (exclude debug statements)

## Test plan
- [ ] Verify build completes successfully with Sentry config
- [ ] Confirm source maps are uploaded to Sentry during production build (requires valid Sentry tokens)
- [ ] Check that source maps are hidden in browser devtools

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)