### PR TITLE
feat(analytics): add PostHog tracking events (#143)

### DIFF
--- a/src/components/v2/FileUpload/FileUploadModal.tsx
+++ b/src/components/v2/FileUpload/FileUploadModal.tsx
@@ -10,6 +10,7 @@ import {
   AlertCircle
 } from 'lucide-react'
 import { getAuthToken } from '@/lib/auth/cookies'
+import { trackEvent } from '@/components/providers/PostHogProvider'
 
 interface FileUploadModalProps {
   isOpen: boolean
@@ -160,6 +161,16 @@ export function FileUploadModal({
 
         setUploadProgress(100)
         setSuccess(true)
+
+        // Track document upload event
+        trackEvent('document_uploaded', {
+          document_id: data.id,
+          file_name: files[0].name,
+          file_size: files[0].size,
+          file_type: files[0].type,
+          session_id: sessionId,
+          user_id: userId
+        })
 
         // Wait a bit to show success message
         setTimeout(() => {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -25,6 +25,7 @@ import {
   registerRateLimiter,
   RATE_LIMIT_CONFIGS
 } from '@/lib/utils/rate-limiter'
+import { trackEvent } from '@/components/providers/PostHogProvider'
 
 // Simplified user type for context (matches API /auth/me response)
 interface ContextUser {
@@ -107,6 +108,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       // Reset rate limiter on successful login
       loginRateLimiter.reset('login')
 
+      // Track login event
+      trackEvent('user_logged_in', {
+        method: 'email',
+        user_id: userData.id
+      })
+
       toast.success('Login realizado com sucesso!')
     } catch (error) {
       const message =
@@ -147,6 +154,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
         // Reset rate limiter on successful registration
         registerRateLimiter.reset('register')
+
+        // Track signup event
+        trackEvent('user_signed_up', {
+          method: 'email'
+        })
 
         // Auto login after register
         await login(data.email, data.password)

--- a/src/hooks/useAIStreamHandler.tsx
+++ b/src/hooks/useAIStreamHandler.tsx
@@ -6,6 +6,7 @@ import { useShallow } from 'zustand/react/shallow'
 import useChatActions from '@/hooks/useChatActions'
 import { usePlaygroundStore } from '../store'
 import { useAuth } from '@/contexts/AuthContext'
+import { trackEvent } from '@/components/providers/PostHogProvider'
 
 /**
  * Chat response from backend
@@ -146,6 +147,15 @@ const useAIChatStreamHandler = () => {
         }
 
         const data: ChatResponse = await response.json()
+
+        // Track chat message event
+        trackEvent('chat_message_sent', {
+          session_id: data.session_id,
+          message_length: message.trim().length,
+          has_files: files && files.length > 0,
+          file_count: files?.length || 0,
+          is_new_session: data.session_id !== sessionId
+        })
 
         // Update session ID if backend returned a new one
         if (data.session_id && data.session_id !== sessionId) {

--- a/src/hooks/useChatFiles.ts
+++ b/src/hooks/useChatFiles.ts
@@ -8,6 +8,7 @@ import type {
 } from '@/types/chat-files'
 import { getFileCategory, getFileExtension } from '@/lib/utils/file-utils'
 import { getAuthToken } from '@/lib/auth/cookies'
+import { trackEvent } from '@/components/providers/PostHogProvider'
 
 // ============================================================================
 // Types
@@ -237,6 +238,16 @@ export function useChatFiles(
               : p
           )
         )
+
+        // Track document upload event
+        trackEvent('document_uploaded', {
+          document_id: newFile.id,
+          file_name: newFile.fileName,
+          file_size: newFile.fileSize,
+          file_type: newFile.mimeType,
+          file_category: newFile.fileCategory,
+          conversation_id: conversationId
+        })
 
         // Remove from progress after delay (with cleanup tracking)
         const timeoutId = setTimeout(() => {


### PR DESCRIPTION
## Summary
Add PostHog event tracking for key user actions to enable product analytics:

- **Authentication events** (`AuthContext.tsx`):
  - `user_logged_in`: tracks method (email) and user_id
  - `user_signed_up`: tracks method (email)

- **Chat events** (`useAIStreamHandler.tsx`):
  - `chat_message_sent`: tracks session_id, message_length, has_files, file_count, is_new_session

- **Document upload events** (`useChatFiles.ts`, `FileUploadModal.tsx`):
  - `document_uploaded`: tracks document_id, file_name, file_size, file_type, file_category, conversation_id

## Test plan
- [ ] Login and verify `user_logged_in` event in PostHog
- [ ] Sign up and verify `user_signed_up` event in PostHog
- [ ] Send a chat message and verify `chat_message_sent` event
- [ ] Upload a document and verify `document_uploaded` event
- [ ] Verify all event properties are captured correctly

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)