### PR TITLE
docs: add LangGraph migration plan and environment variables guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ storybook-static/
 
 # Agent
 .claude/
+.codex-git/

--- a/docs/MIGRACAO_DIALOGFLOW_LANGGRAPH.md
+++ b/docs/MIGRACAO_DIALOGFLOW_LANGGRAPH.md
@@ -1,0 +1,581 @@
+# Migração Dialogflow CX → LangGraph
+
+> Plano de migração dos workflows de CPR do Dialogflow CX para LangGraph 1.0.5
+>
+> Atualizado: 2025-12-16
+
+> Nota: este documento descreve a arquitetura e implementação no **backend** (FastAPI). Os paths citados (ex.: `app/agents/...`) pertencem ao repositório do backend.
+
+---
+
+## 📋 Índice
+
+- [Visão Geral](#visão-geral)
+- [Estado Atual (Dialogflow CX)](#estado-atual-dialogflow-cx)
+- [Arquitetura Alvo (LangGraph)](#arquitetura-alvo-langgraph)
+- [Workflows a Migrar](#workflows-a-migrar)
+- [Plano de Migração](#plano-de-migração)
+- [Variáveis de Ambiente](#variáveis-de-ambiente)
+- [Testes](#testes)
+- [Rollback Strategy](#rollback-strategy)
+
+---
+
+## Visão Geral
+
+### Por que migrar?
+
+| Aspecto               | Dialogflow CX        | LangGraph              |
+| --------------------- | -------------------- | ---------------------- |
+| **Custo**             | $$$ (por requisição) | $ (apenas LLM)         |
+| **Controle**          | Limitado (GUI)       | Total (código)         |
+| **Flexibilidade**     | Flows pré-definidos  | Grafos customizáveis   |
+| **Human-in-the-loop** | Limitado             | Nativo (`interrupt()`) |
+| **Debugging**         | Console GCP          | Logs + Langfuse        |
+| **Versioning**        | Console GUI          | Git (código)           |
+| **Observabilidade**   | GCP Logs             | Langfuse/LangSmith     |
+| **Latência**          | Mais alta (2 hops)   | Menor (direto)         |
+| **Multi-modelo**      | Não                  | Sim (OpenRouter)       |
+
+### Benefícios da Migração
+
+✅ **Redução de custos** - Elimina cobrança por requisição do Dialogflow
+✅ **Maior controle** - Workflows em Python (versionados no Git)
+✅ **Melhor debugging** - Logs estruturados + Langfuse tracing
+✅ **Human-in-the-loop nativo** - `interrupt()` + `Command(resume=...)`
+✅ **Multi-modelo** - Usar modelos grátis do OpenRouter por tarefa
+✅ **Persistência de estado** - PostgreSQL checkpointer integrado
+✅ **Observabilidade** - Langfuse para monitorar cada etapa do workflow
+
+---
+
+## Estado Atual (Dialogflow CX)
+
+### Endpoint Existente
+
+```
+POST /api/v1/dialogflow/webhook
+```
+
+**Flows ativos:**
+
+1. **analise_cpr** - Análise de documentos CPR
+2. **criar_cpr** - Criação de novos CPRs
+
+### Flow: analise_cpr
+
+| Tag                   | Descrição              | Ação              |
+| --------------------- | ---------------------- | ----------------- |
+| `processar_documento` | Extrai texto do PDF    | Gemini Vision     |
+| `confirmar_dados`     | Valida dados extraídos | Human-in-the-loop |
+| `validar_compliance`  | Verifica Lei 8.929/94  | Llama 3.3 70B     |
+| `calcular_risco`      | Score de risco         | Llama 3.3 70B     |
+| `resultado_final`     | Gera relatório         | Mistral 7B        |
+
+### Flow: criar_cpr
+
+| Tag                     | Descrição               | Ação              |
+| ----------------------- | ----------------------- | ----------------- |
+| `coletar_dados_basicos` | Tipo, emitente, credor  | Gemini Flash      |
+| `coletar_quantidade`    | Produto e quantidade    | Gemini Flash      |
+| `coletar_valor`         | Valores e prazos        | Gemini Flash      |
+| `confirmar_cpr`         | Validação final         | Human-in-the-loop |
+| `gerar_cpr`             | Gera documento Word/PDF | Llama 3.3 70B     |
+
+### Variáveis Dialogflow (A REMOVER)
+
+```bash
+DIALOGFLOW_PROJECT_ID=xxx
+DIALOGFLOW_AGENT_ID=xxx
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+```
+
+---
+
+## Arquitetura Alvo (LangGraph)
+
+### Estrutura de Arquivos (Backend)
+
+```
+app/
+├── agents/                          # LangGraph workflows
+│   ├── __init__.py
+│   ├── analise_cpr.py              # Flow de análise
+│   ├── criar_cpr.py                # Flow de criação
+│   └── shared/
+│       ├── llm_router.py           # Seleção de modelo por tarefa
+│       ├── checkpointer.py         # PostgreSQL checkpointer
+│       └── interrupts.py           # Helpers para interrupt/resume
+├── api/
+│   └── routes/
+│       └── chat.py                 # Roteamento de workflows
+└── core/
+    └── config.py                   # Configurações LangGraph
+```
+
+### Fluxo de Roteamento
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      POST /api/v1/chat                          │
+└────────────────────────────┬────────────────────────────────────┘
+                             │
+                             ▼
+           ┌─────────────────────────────────┐
+           │   Tem workflow ativo?           │
+           │   (check PostgreSQL state)      │
+           └─────────┬───────────────────────┘
+                     │
+         ┌───────────┴──────────┐
+         │ Sim                  │ Não
+         ▼                      ▼
+   ┌──────────┐         ┌──────────────┐
+   │ Resume   │         │ Detectar     │
+   │ workflow │         │ intent       │
+   └──────────┘         └──────┬───────┘
+                               │
+                    ┌──────────┴───────────┐
+                    │ "analisar cpr"       │ "criar cpr"
+                    ▼                      ▼
+           ┌────────────────┐     ┌────────────────┐
+           │ Start          │     │ Start          │
+           │ analise_cpr    │     │ criar_cpr      │
+           │ workflow       │     │ workflow       │
+           └────────────────┘     └────────────────┘
+```
+
+---
+
+## Workflows a Migrar
+
+### Workflow 1: analise_cpr
+
+#### Estado no LangGraph
+
+```python
+class AnaliseState(TypedDict):
+    session_id: str
+    document_id: str
+    extracted_text: str
+    dados_validados: dict
+    compliance_result: dict
+    risco_score: float
+    relatorio_final: str
+    analise_completa: bool
+    messages: list
+```
+
+#### Nós do Grafo
+
+```python
+graph = StateGraph(AnaliseState)
+
+# Nós
+graph.add_node("extrair_texto", extrair_texto_node)
+graph.add_node("validar_dados", validar_dados_node)
+graph.add_node("aguardar_confirmacao", aguardar_confirmacao_node)  # interrupt()
+graph.add_node("validar_compliance", validar_compliance_node)
+graph.add_node("calcular_risco", calcular_risco_node)
+graph.add_node("gerar_relatorio", gerar_relatorio_node)
+
+# Edges
+graph.add_edge(START, "extrair_texto")
+graph.add_edge("extrair_texto", "validar_dados")
+graph.add_edge("validar_dados", "aguardar_confirmacao")
+graph.add_conditional_edges(
+    "aguardar_confirmacao",
+    lambda s: "prosseguir" if s.get("dados_validados") else "revalidar",
+    {
+        "prosseguir": "validar_compliance",
+        "revalidar": "validar_dados"
+    }
+)
+graph.add_edge("validar_compliance", "calcular_risco")
+graph.add_edge("calcular_risco", "gerar_relatorio")
+graph.add_edge("gerar_relatorio", END)
+```
+
+#### Mapeamento de Modelos
+
+| Nó                   | Modelo (OpenRouter)                      | Temperatura | Justificativa             |
+| -------------------- | ---------------------------------------- | ----------- | ------------------------- |
+| `extrair_texto`      | `qwen/qwen-2.5-72b-instruct:free`        | 0.0         | Extração estruturada JSON |
+| `validar_dados`      | `meta-llama/llama-3.3-70b-instruct:free` | 0.1         | Validação lógica          |
+| `validar_compliance` | `meta-llama/llama-3.3-70b-instruct:free` | 0.1         | Raciocínio jurídico       |
+| `calcular_risco`     | `meta-llama/llama-3.3-70b-instruct:free` | 0.1         | Análise quantitativa      |
+| `gerar_relatorio`    | `mistralai/mistral-7b-instruct:free`     | 0.3         | Formatação de texto       |
+
+#### Interrupt Points
+
+```python
+# Após validação de dados (aguardar confirmação do usuário)
+if not state.get("dados_confirmados"):
+    interrupt("Confirme os dados extraídos antes de prosseguir")
+```
+
+---
+
+### Workflow 2: criar_cpr
+
+#### Estado no LangGraph
+
+```python
+class CriarCPRState(TypedDict):
+    session_id: str
+    tipo_cpr: str  # "fisica" | "financeira"
+    dados_emitente: dict
+    dados_credor: dict
+    produto: dict
+    valores: dict
+    garantias: dict
+    documento_gerado: bool
+    documento_url: str
+    messages: list
+```
+
+#### Nós do Grafo
+
+```python
+graph = StateGraph(CriarCPRState)
+
+# Nós
+graph.add_node("coletar_tipo", coletar_tipo_node)
+graph.add_node("coletar_emitente", coletar_emitente_node)
+graph.add_node("coletar_credor", coletar_credor_node)
+graph.add_node("coletar_produto", coletar_produto_node)
+graph.add_node("coletar_valores", coletar_valores_node)
+graph.add_node("coletar_garantias", coletar_garantias_node)
+graph.add_node("revisar_dados", revisar_dados_node)
+graph.add_node("aguardar_confirmacao", aguardar_confirmacao_node)  # interrupt()
+graph.add_node("gerar_documento", gerar_documento_node)
+
+# Edges
+graph.add_edge(START, "coletar_tipo")
+graph.add_edge("coletar_tipo", "coletar_emitente")
+graph.add_edge("coletar_emitente", "coletar_credor")
+graph.add_edge("coletar_credor", "coletar_produto")
+graph.add_edge("coletar_produto", "coletar_valores")
+graph.add_edge("coletar_valores", "coletar_garantias")
+graph.add_edge("coletar_garantias", "revisar_dados")
+graph.add_edge("revisar_dados", "aguardar_confirmacao")
+graph.add_conditional_edges(
+    "aguardar_confirmacao",
+    lambda s: "gerar" if s.get("confirmado") else "revisar",
+    {
+        "gerar": "gerar_documento",
+        "revisar": "revisar_dados"
+    }
+)
+graph.add_edge("gerar_documento", END)
+```
+
+#### Mapeamento de Modelos
+
+| Nó                | Modelo (OpenRouter)                      | Temperatura | Justificativa               |
+| ----------------- | ---------------------------------------- | ----------- | --------------------------- |
+| `coletar_*`       | `google/gemini-2.0-flash-exp:free`       | 0.5         | Diálogo natural, validações |
+| `revisar_dados`   | `google/gemini-2.0-flash-exp:free`       | 0.3         | Resumo estruturado          |
+| `gerar_documento` | `meta-llama/llama-3.3-70b-instruct:free` | 0.2         | Precisão jurídica           |
+
+#### Interrupt Points
+
+```python
+# Após coleta de todos os dados (aguardar confirmação final)
+if not state.get("confirmado"):
+    interrupt("Revise e confirme os dados antes de gerar o CPR")
+```
+
+---
+
+## Plano de Migração
+
+### Fase 1: Preparação ✅
+
+- [x] Instalar dependências LangGraph
+- [x] Criar estrutura de arquivos
+- [x] Configurar PostgreSQL checkpointer
+- [x] Implementar LLM router com OpenRouter
+
+### Fase 2: Implementação dos Workflows ✅
+
+- [x] Implementar `analise_cpr.py`
+- [x] Implementar `criar_cpr.py`
+- [x] Adicionar interrupt points
+- [x] Testar persistência de estado
+
+### Fase 3: Testes Unitários ✅
+
+- [x] Testes de cada nó isolado
+- [x] Testes de transições
+- [x] Testes de interrupt/resume
+- [x] Testes de edge cases
+
+### Fase 4: Integração com Chat Endpoint ✅
+
+- [x] Modificar `/api/v1/chat`
+- [x] Adicionar detecção de intent
+- [x] Implementar roteamento para workflows
+- [x] Manter fallback para Dialogflow CX (temporário)
+
+### Fase 5: Deploy e Testes em Produção 🔄
+
+- [ ] Configurar variáveis no Railway
+- [ ] Deploy do backend
+- [ ] Testes A/B (Dialogflow vs LangGraph)
+- [ ] Monitorar métricas (latência, erros, custos)
+- [ ] Ajustes baseados em feedback
+
+### Fase 6: Desativação do Dialogflow ⏳
+
+- [ ] Remover endpoint `/api/v1/dialogflow/webhook`
+- [ ] Remover variáveis Dialogflow
+- [ ] Cancelar serviço Dialogflow CX no GCP
+- [ ] Atualizar documentação
+
+---
+
+## Variáveis de Ambiente
+
+### ✅ Adicionar (LangGraph)
+
+```bash
+# OpenRouter para multi-modelo
+OPENROUTER_API_KEY=sk-or-xxx
+
+# LangGraph checkpointer (usa PostgreSQL existente)
+LANGGRAPH_CHECKPOINTER_URL=$DATABASE_URL
+LANGGRAPH_INTERRUPT_ENABLED=true
+
+# Langfuse observability (recomendado)
+LANGFUSE_PUBLIC_KEY=pk-lf-xxx
+LANGFUSE_SECRET_KEY=sk-lf-xxx
+LANGFUSE_HOST=https://cloud.langfuse.com
+```
+
+### ❌ Remover (Após migração completa)
+
+```bash
+DIALOGFLOW_PROJECT_ID=xxx
+DIALOGFLOW_AGENT_ID=xxx
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+```
+
+### ⚠️ Manter (Temporariamente)
+
+Durante a fase de testes A/B, manter ambas configurações:
+
+```bash
+# LangGraph (novo)
+OPENROUTER_API_KEY=xxx
+LANGGRAPH_CHECKPOINTER_URL=xxx
+
+# Dialogflow (fallback)
+DIALOGFLOW_PROJECT_ID=xxx
+DIALOGFLOW_AGENT_ID=xxx
+```
+
+---
+
+## Testes
+
+### Testes Unitários
+
+```bash
+# Testar workflows isolados
+pytest tests/agents/test_analise_cpr.py
+pytest tests/agents/test_criar_cpr.py
+
+# Testar interrupt/resume
+pytest tests/agents/test_interrupts.py
+
+# Testar checkpointer
+pytest tests/agents/test_persistence.py
+```
+
+### Testes de Integração
+
+```bash
+# Testar roteamento no endpoint /chat
+pytest tests/api/test_chat_routing.py
+
+# Testar fluxo completo analise_cpr
+pytest tests/integration/test_analise_flow.py
+
+# Testar fluxo completo criar_cpr
+pytest tests/integration/test_criar_flow.py
+```
+
+### Testes Manuais (Staging)
+
+1. **Análise de CPR**:
+   - Enviar mensagem: "Quero analisar um CPR"
+   - Fazer upload de documento PDF
+   - Verificar extração de dados
+   - Confirmar dados extraídos
+   - Verificar relatório de compliance
+   - Verificar cálculo de risco
+
+2. **Criação de CPR**:
+   - Enviar mensagem: "Quero criar um CPR"
+   - Seguir wizard de coleta de dados
+   - Revisar dados coletados
+   - Confirmar geração
+   - Verificar documento gerado
+
+3. **Interrupt/Resume**:
+   - Iniciar workflow
+   - Sair no meio (fechar navegador)
+   - Voltar depois
+   - Enviar nova mensagem
+   - Verificar que workflow continua de onde parou
+
+---
+
+## Rollback Strategy
+
+### Se encontrar problemas críticos
+
+#### Opção 1: Rollback Rápido (Endpoint)
+
+```python
+# Em app/api/routes/chat.py
+USE_LANGGRAPH = os.getenv("ENABLE_LANGGRAPH", "false") == "true"
+
+if USE_LANGGRAPH:
+    # Tentar LangGraph
+    try:
+        response = await langgraph_handler(...)
+    except Exception as e:
+        logger.error(f"LangGraph failed, fallback to Dialogflow: {e}")
+        response = dialogflow_handler(...)
+else:
+    # Usar apenas Dialogflow
+    response = dialogflow_handler(...)
+```
+
+Rollback:
+
+```bash
+railway variables set ENABLE_LANGGRAPH=false
+```
+
+#### Opção 2: Rollback via Railway
+
+```bash
+# Ver deployments
+railway deployments
+
+# Fazer rollback para versão anterior
+railway rollback <deployment-id>
+```
+
+#### Opção 3: Rollback via Git
+
+```bash
+# Reverter commit
+git revert <commit-hash>
+git push
+
+# Railway faz deploy automático
+```
+
+---
+
+## Monitoramento
+
+### Métricas a Acompanhar
+
+| Métrica               | Dialogflow CX | LangGraph (Alvo) |
+| --------------------- | ------------- | ---------------- |
+| **Latência média**    | ~2-3s         | <1.5s            |
+| **Taxa de erro**      | <1%           | <0.5%            |
+| **Custo/1000 req**    | ~$10-20       | ~$2-5            |
+| **Taxa de conclusão** | ~80%          | >90%             |
+
+### Dashboards
+
+1. **Langfuse** - Tracing de workflows
+   - Tempo por nó
+   - Tokens consumidos por modelo
+   - Taxa de sucesso/falha
+   - Custo por workflow
+
+2. **PostHog** - Analytics de produto
+   - Eventos de início/conclusão de workflow
+   - Tempo médio de conclusão
+   - Taxa de abandono
+
+3. **Sentry** - Error tracking
+   - Erros por nó do workflow
+   - Stack traces
+   - Alertas em tempo real
+
+---
+
+## Cronograma Estimado
+
+| Fase                           | Duração     | Status           |
+| ------------------------------ | ----------- | ---------------- |
+| Fase 1: Preparação             | 2 dias      | ✅ Concluído     |
+| Fase 2: Implementação          | 3 dias      | ✅ Concluído     |
+| Fase 3: Testes Unitários       | 2 dias      | ✅ Concluído     |
+| Fase 4: Integração             | 1 dia       | ✅ Concluído     |
+| Fase 5: Deploy + Testes        | 3 dias      | 🔄 Em andamento  |
+| Fase 6: Desativação Dialogflow | 1 dia       | ⏳ Pendente      |
+| **Total**                      | **12 dias** | **83% completo** |
+
+---
+
+## Checklist Final
+
+### Antes do Deploy
+
+- [ ] Todas as variáveis configuradas no Railway
+- [ ] `OPENROUTER_API_KEY` válida e testada
+- [ ] `LANGGRAPH_CHECKPOINTER_URL` apontando para PostgreSQL
+- [ ] `LANGFUSE_*` configurado (opcional mas recomendado)
+- [ ] Testes unitários passando (98 testes OK)
+- [ ] Testes de integração criados
+- [ ] Documentação atualizada
+
+### Após o Deploy
+
+- [ ] Verificar health check: `/api/v1/health/`
+- [ ] Testar workflow analise_cpr end-to-end
+- [ ] Testar workflow criar_cpr end-to-end
+- [ ] Verificar logs no Railway
+- [ ] Verificar traces no Langfuse
+- [ ] Monitorar erros no Sentry
+- [ ] Monitorar eventos no PostHog
+- [ ] Comparar latência: Dialogflow vs LangGraph
+- [ ] Comparar custos após 1 semana
+
+### Após 1 Semana de Testes A/B
+
+- [ ] Analisar métricas de performance
+- [ ] Analisar feedback de usuários
+- [ ] Decidir: continuar LangGraph ou rollback
+- [ ] Se OK: remover Dialogflow (Fase 6)
+- [ ] Atualizar documentação final
+
+---
+
+## Recursos
+
+### Documentação
+
+- [LangGraph Docs](https://langchain-ai.github.io/langgraph/)
+- [LangGraph Checkpointer](https://langchain-ai.github.io/langgraph/how-tos/persistence/)
+- [LangGraph Human-in-the-loop](https://langchain-ai.github.io/langgraph/how-tos/human-in-the-loop/)
+- [OpenRouter Docs](https://openrouter.ai/docs)
+- [Langfuse Docs](https://langfuse.com/docs)
+
+### Exemplos de Código
+
+- `app/agents/analise_cpr.py` - Workflow de análise
+- `app/agents/criar_cpr.py` - Workflow de criação
+- `app/api/routes/chat.py` - Roteamento de workflows
+
+---
+
+**Última atualização**: 2025-12-16 | [Voltar ao índice](#-índice)

--- a/docs/VARIAVEIS_AMBIENTE.md
+++ b/docs/VARIAVEIS_AMBIENTE.md
@@ -1,0 +1,376 @@
+# Variáveis de Ambiente - Verity Agro
+
+> Lista completa de variáveis necessárias para desenvolvimento e produção
+> Atualizado: 2025-12-16
+
+> Segurança: nunca commite chaves/token em git. Use `.env`/`.env.local` no local e variables no provedor (Vercel/Railway).
+
+---
+
+## 📋 Índice
+
+- [Frontend (Next.js - Vercel)](#frontend-nextjs---vercel)
+- [Backend (FastAPI - Railway)](#backend-fastapi---railway)
+- [Como Configurar](#como-configurar)
+- [Checklist de Deploy](#checklist-de-deploy)
+
+---
+
+## Frontend (Next.js - Vercel)
+
+### ✅ Obrigatórias
+
+| Variável              | Exemplo                                                  | Descrição                        |
+| --------------------- | -------------------------------------------------------- | -------------------------------- |
+| `NEXT_PUBLIC_API_URL` | `https://rodrigues-ai-backend-production.up.railway.app` | URL do backend FastAPI           |
+| `NEXT_PUBLIC_APP_URL` | `https://ai.verityagro.com`                              | URL do frontend (auto na Vercel) |
+| `RESEND_API_KEY`      | `re_xxxxxxxxxxxxx`                                       | API key do Resend para emails    |
+| `EMAIL_FROM`          | `no-reply@verityagro.com`                                | Email remetente                  |
+| `EMAIL_FROM_NAME`     | `Verity Agro`                                            | Nome do remetente                |
+
+### 📊 Analytics & Monitoramento
+
+| Variável                   | Exemplo                                | Descrição             |
+| -------------------------- | -------------------------------------- | --------------------- |
+| `NEXT_PUBLIC_POSTHOG_KEY`  | `phc_xxxxxxxxxxxxx`                    | PostHog analytics key |
+| `NEXT_PUBLIC_POSTHOG_HOST` | `https://us.i.posthog.com`             | PostHog host          |
+| `NEXT_PUBLIC_SENTRY_DSN`   | `https://xxx@xxx.ingest.sentry.io/xxx` | Sentry error tracking |
+
+### 🔧 Opcionais
+
+| Variável                          | Exemplo                                                  | Descrição                |
+| --------------------------------- | -------------------------------------------------------- | ------------------------ |
+| `NEXT_PUBLIC_PLAYGROUND_ENDPOINT` | `https://rodrigues-ai-backend-production.up.railway.app` | Endpoint para playground |
+| `NEXT_PUBLIC_FRONTEND_URL`        | `http://localhost:3000`                                  | URL frontend (dev)       |
+| `UPSTASH_REDIS_REST_URL`          | `https://xxx.upstash.io`                                 | Redis cache (opcional)   |
+| `UPSTASH_REDIS_REST_TOKEN`        | `xxxxxxxxxxxxx`                                          | Token Redis              |
+
+### 📝 Build Configuration
+
+| Variável                         | Valor        | Descrição                         |
+| -------------------------------- | ------------ | --------------------------------- |
+| `NODE_ENV`                       | `production` | Ambiente (auto na Vercel)         |
+| `ESLINT_IGNORE_DURING_BUILD`     | `false`      | Ignorar erros ESLint no build     |
+| `TYPESCRIPT_IGNORE_BUILD_ERRORS` | `false`      | Ignorar erros TypeScript no build |
+
+---
+
+## Backend (FastAPI - Railway)
+
+### 🗄️ Database (PostgreSQL)
+
+| Variável            | Exemplo                               | Descrição                          |
+| ------------------- | ------------------------------------- | ---------------------------------- |
+| `POSTGRES_SERVER`   | `postgres.railway.internal`           | Host do PostgreSQL (Railway provê) |
+| `POSTGRES_USER`     | `postgres`                            | Usuário do banco (Railway provê)   |
+| `POSTGRES_PASSWORD` | `xxxxxxxxxxxxx`                       | Senha do banco (Railway provê)     |
+| `POSTGRES_DB`       | `railway`                             | Nome do banco (Railway provê)      |
+| `POSTGRES_PORT`     | `5432`                                | Porta do PostgreSQL                |
+| `DATABASE_URL`      | `postgresql://user:pass@host:5432/db` | URL completa (Railway auto-gera)   |
+
+> ⚠️ **Railway**: Não precisa configurar manualmente. Ao adicionar PostgreSQL no Railway, essas variáveis são injetadas automaticamente.
+
+### 🔑 AI/LLM Services
+
+| Variável                         | Obrigatória | Descrição                                  |
+| -------------------------------- | ----------- | ------------------------------------------ |
+| `GOOGLE_API_KEY`                 | ✅ Sim      | Google Gemini API key                      |
+| `OPENROUTER_API_KEY`             | ✅ Sim      | OpenRouter API para modelos grátis         |
+| `AGNO_API_KEY`                   | ❌ Opcional | Agno API (se usado)                        |
+| `DIALOGFLOW_PROJECT_ID`          | ❌ Migrar   | Projeto Dialogflow CX (será removido)      |
+| `DIALOGFLOW_AGENT_ID`            | ❌ Migrar   | Agent Dialogflow CX (será removido)        |
+| `GOOGLE_APPLICATION_CREDENTIALS` | ❌ Migrar   | Path para service account (Dialogflow/GCS) |
+
+### 🔐 Security & Auth
+
+| Variável                              | Exemplo                    | Descrição                                          |
+| ------------------------------------- | -------------------------- | -------------------------------------------------- |
+| `SECRET_KEY`                          | `xxxxxxxxxxxxxxxxxxxxxxxx` | JWT secret (gerar com `secrets.token_urlsafe(32)`) |
+| `ACCESS_TOKEN_EXPIRE_MINUTES`         | `11520`                    | Expiração token (8 dias)                           |
+| `RESET_PASSWORD_TOKEN_EXPIRE_MINUTES` | `30`                       | Expiração token reset senha                        |
+
+### 🌐 CORS & URLs
+
+| Variável               | Exemplo                                          | Descrição                                  |
+| ---------------------- | ------------------------------------------------ | ------------------------------------------ |
+| `FRONTEND_URL`         | `https://ai.verityagro.com`                      | URL do frontend                            |
+| `BACKEND_CORS_ORIGINS` | `https://ai.verityagro.com,https://app.agno.com` | Origens permitidas (separadas por vírgula) |
+| `NEXT_PUBLIC_API_URL`  | `https://api.verityagro.com`                     | URL pública da API                         |
+| `NEXT_PUBLIC_APP_URL`  | `https://ai.verityagro.com`                      | URL pública do app                         |
+
+### 📦 Vector Database (Qdrant)
+
+| Variável                 | Exemplo                           | Descrição                            |
+| ------------------------ | --------------------------------- | ------------------------------------ |
+| `QDRANT_HOST`            | `qdrant`                          | Host do Qdrant (Docker) ou URL cloud |
+| `QDRANT_PORT`            | `6333`                            | Porta do Qdrant                      |
+| `QDRANT_API_KEY`         | `xxxxxxxxxxxxx`                   | API key (se Qdrant Cloud)            |
+| `QDRANT_COLLECTION_NAME` | `prod--rodrigues-ai-credito-agro` | Nome da coleção                      |
+| `QDRANT_URL`             | `https://xxx.cloud.qdrant.io`     | URL completa (se Qdrant Cloud)       |
+
+> 💡 **Opção 1 (Auto-hospedado)**: Deploy Qdrant no Railway como serviço separado
+> 💡 **Opção 2 (Cloud)**: Usar Qdrant Cloud (free tier: 1GB)
+
+### 📧 Email (SMTP)
+
+| Variável          | Exemplo                  | Descrição       |
+| ----------------- | ------------------------ | --------------- |
+| `SMTP_HOST`       | `smtp.gmail.com`         | Host SMTP       |
+| `SMTP_PORT`       | `587`                    | Porta SMTP      |
+| `SMTP_USER`       | `noreply@verityagro.com` | Usuário SMTP    |
+| `SMTP_PASSWORD`   | `xxxxxxxxxxxxx`          | Senha SMTP      |
+| `EMAIL_FROM`      | `noreply@verityagro.com` | Email remetente |
+| `EMAIL_FROM_NAME` | `Rodrigues AI`           | Nome remetente  |
+
+### 📊 Observability
+
+| Variável              | Obrigatória    | Descrição                                    |
+| --------------------- | -------------- | -------------------------------------------- |
+| `LANGFUSE_PUBLIC_KEY` | ❌ Recomendada | Langfuse tracing (free: 50k traces/mês)      |
+| `LANGFUSE_SECRET_KEY` | ❌ Recomendada | Langfuse secret                              |
+| `LANGFUSE_HOST`       | ❌ Recomendada | `https://cloud.langfuse.com`                 |
+| `SENTRY_DSN`          | ❌ Recomendada | Sentry error tracking (free: 5k eventos/mês) |
+| `POSTHOG_API_KEY`     | ❌ Recomendada | PostHog analytics (backend)                  |
+| `POSTHOG_HOST`        | ❌ Recomendada | `https://us.i.posthog.com`                   |
+
+### ⚙️ Application Config
+
+| Variável                | Valor        | Descrição                                 |
+| ----------------------- | ------------ | ----------------------------------------- |
+| `ENVIRONMENT`           | `production` | Ambiente: local, staging, production      |
+| `NODE_ENV`              | `production` | Node environment                          |
+| `DOCS_ENABLED`          | `false`      | Mostrar docs Swagger (false em produção)  |
+| `LOG_LEVEL`             | `INFO`       | Nível de log: DEBUG, INFO, WARNING, ERROR |
+| `RATE_LIMIT_PER_MINUTE` | `60`         | Rate limiting (requisições/minuto)        |
+
+### 🔄 LangGraph/LangChain (NOVO - Migração do Dialogflow)
+
+| Variável                      | Obrigatória | Descrição                                                   |
+| ----------------------------- | ----------- | ----------------------------------------------------------- |
+| `LANGGRAPH_CHECKPOINTER_URL`  | ✅ Sim      | URL do PostgreSQL para checkpointer (mesma do DATABASE_URL) |
+| `LANGGRAPH_INTERRUPT_ENABLED` | ✅ Sim      | `true` - Ativar interrupts para human-in-the-loop           |
+| `LANGGRAPH_VERSION`           | ℹ️ Info     | `1.0.5` (documentação)                                      |
+
+---
+
+## 🚀 Como Configurar
+
+### Desenvolvimento Local
+
+1. **Frontend** (`.env.local`):
+
+```bash
+cp .env.example .env.local
+# Edite .env.local com suas keys
+```
+
+2. **Backend** (`.env`):
+
+```bash
+cp .env.example .env
+# Edite .env com suas keys locais
+```
+
+### Produção (Railway - Backend)
+
+#### Opção 1: Via Dashboard Railway
+
+1. Acesse o projeto no Railway
+2. Clique em "Variables"
+3. Adicione cada variável manualmente
+
+#### Opção 2: Via Railway CLI
+
+```bash
+# Instalar Railway CLI
+npm install -g @railway/cli
+
+# Login
+railway login
+
+# Link com projeto
+railway link
+
+# Adicionar variáveis (uma por vez)
+railway variables set GOOGLE_API_KEY=sua_key_aqui
+railway variables set OPENROUTER_API_KEY=sua_key_aqui
+railway variables set SECRET_KEY=$(python -c "import secrets; print(secrets.token_urlsafe(32))")
+railway variables set ENVIRONMENT=production
+railway variables set DOCS_ENABLED=false
+
+# Ver todas variáveis
+railway variables
+```
+
+#### Opção 3: Usar arquivo .env (CUIDADO!)
+
+```bash
+# Criar arquivo .railway.env localmente (NÃO commitar!)
+cat > .railway.env << 'EOF'
+GOOGLE_API_KEY=xxx
+OPENROUTER_API_KEY=xxx
+SECRET_KEY=xxx
+ENVIRONMENT=production
+DOCS_ENABLED=false
+# ... demais variáveis
+EOF
+
+# Importar de uma vez (Railway CLI)
+railway variables set --from-file .railway.env
+
+# DELETAR arquivo depois!
+rm .railway.env
+```
+
+### Produção (Vercel - Frontend)
+
+```bash
+# Instalar Vercel CLI
+npm install -g vercel
+
+# Login
+vercel login
+
+# Link com projeto
+vercel link
+
+# Adicionar variáveis de produção
+vercel env add NEXT_PUBLIC_API_URL production
+vercel env add NEXT_PUBLIC_POSTHOG_KEY production
+vercel env add RESEND_API_KEY production
+
+# Ou via dashboard Vercel > Settings > Environment Variables
+```
+
+---
+
+## ✅ Checklist de Deploy
+
+### Backend (Railway)
+
+- [ ] PostgreSQL adicionado como serviço
+- [ ] `DATABASE_URL` auto-gerada pelo Railway
+- [ ] `GOOGLE_API_KEY` configurada
+- [ ] `OPENROUTER_API_KEY` configurada
+- [ ] `SECRET_KEY` gerada e configurada
+- [ ] `ENVIRONMENT=production`
+- [ ] `DOCS_ENABLED=false`
+- [ ] `FRONTEND_URL` apontando para Vercel
+- [ ] `BACKEND_CORS_ORIGINS` incluindo domínio Vercel
+- [ ] Qdrant configurado (cloud ou serviço Railway)
+- [ ] `QDRANT_URL` ou `QDRANT_HOST` + `QDRANT_PORT`
+- [ ] Langfuse configurado (cloud.langfuse.com)
+- [ ] `LANGFUSE_PUBLIC_KEY` e `LANGFUSE_SECRET_KEY`
+- [ ] Sentry DSN configurada
+- [ ] PostHog API key configurada (se usar no backend)
+- [ ] `LANGGRAPH_CHECKPOINTER_URL` = `DATABASE_URL`
+- [ ] `LANGGRAPH_INTERRUPT_ENABLED=true`
+
+### Frontend (Vercel)
+
+- [ ] `NEXT_PUBLIC_API_URL` apontando para Railway
+- [ ] `NEXT_PUBLIC_APP_URL` apontando para domínio Vercel
+- [ ] `RESEND_API_KEY` configurada
+- [ ] `EMAIL_FROM` configurado
+- [ ] `EMAIL_FROM_NAME` configurado
+- [ ] `NEXT_PUBLIC_POSTHOG_KEY` configurada
+- [ ] `NEXT_PUBLIC_POSTHOG_HOST` configurada
+- [ ] `NEXT_PUBLIC_SENTRY_DSN` configurada
+- [ ] Domínio customizado configurado (opcional)
+
+### Verificação Pós-Deploy
+
+```bash
+# Testar saúde do backend
+curl https://rodrigues-ai-backend-production.up.railway.app/api/v1/health/
+
+# Testar docs (se DOCS_ENABLED=true em staging)
+curl https://rodrigues-ai-backend-production.up.railway.app/docs
+
+# Verificar frontend
+curl https://ai.verityagro.com
+```
+
+---
+
+## 🔍 Variáveis Faltando (Conforme Código Atual)
+
+### Backend - URGENTE
+
+1. **`OPENROUTER_API_KEY`** ⚠️
+   - Necessária para usar modelos grátis do OpenRouter
+   - Referenciada em `model_mapping.md`
+   - Cadastro: https://openrouter.ai/
+
+2. **`LANGGRAPH_CHECKPOINTER_URL`** ⚠️
+   - Necessária para persistência de estado LangGraph
+   - Usar mesma URL do PostgreSQL
+   - Valor: `${{DATABASE_URL}}` (Railway)
+
+3. **`LANGGRAPH_INTERRUPT_ENABLED`** ⚠️
+   - Ativar human-in-the-loop workflows
+   - Valor: `true`
+
+### Backend - RECOMENDADAS
+
+4. **`LANGFUSE_PUBLIC_KEY`** + `LANGFUSE_SECRET_KEY`\*\* 📊
+   - Observabilidade LLM essencial
+   - Free tier: 50.000 traces/mês
+   - Cadastro: https://cloud.langfuse.com
+
+5. **`QDRANT_URL`** ou **`QDRANT_HOST`** 🔍
+   - Necessária para RAG funcionar
+   - Opção cloud (free): https://qdrant.tech/cloud/
+   - Opção self-hosted: Deploy no Railway
+
+### Backend - MIGRAÇÃO DIALOGFLOW → LANGGRAPH
+
+6. **Remover após migração completa**:
+   - `DIALOGFLOW_PROJECT_ID`
+   - `DIALOGFLOW_AGENT_ID`
+   - `GOOGLE_APPLICATION_CREDENTIALS`
+
+7. **Manter temporariamente** (até fase 5 completa):
+   - Endpoint `/api/v1/dialogflow/webhook` ainda ativo
+   - Variáveis Dialogflow necessárias para fallback
+
+---
+
+## 📖 Referências
+
+- [Railway Docs - Environment Variables](https://docs.railway.app/develop/variables)
+- [Vercel Docs - Environment Variables](https://vercel.com/docs/projects/environment-variables)
+- [Next.js Docs - Environment Variables](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables)
+- [FastAPI Settings Management](https://fastapi.tiangolo.com/advanced/settings/)
+- [LangGraph Checkpointer Docs](https://langchain-ai.github.io/langgraph/how-tos/persistence/)
+
+---
+
+## 🆘 Troubleshooting
+
+### Erro: "Database connection failed"
+
+- Verificar `DATABASE_URL` no Railway
+- Conferir se PostgreSQL está running
+- Testar conexão: `railway run psql $DATABASE_URL`
+
+### Erro: "CORS policy blocked"
+
+- Verificar `BACKEND_CORS_ORIGINS` inclui domínio do frontend
+- Formato: `https://dominio1.com,https://dominio2.com` (sem espaços)
+
+### Erro: "API key invalid" (Google/OpenRouter)
+
+- Verificar se keys estão corretas
+- Google: https://aistudio.google.com/apikey
+- OpenRouter: https://openrouter.ai/keys
+
+### Erro: "Langfuse not initialized"
+
+- Verificar `LANGFUSE_PUBLIC_KEY` e `LANGFUSE_SECRET_KEY`
+- Verificar `LANGFUSE_HOST` (default: https://cloud.langfuse.com)
+- Não é crítico, mas prejudica observabilidade
+
+---
+
+**Última atualização**: 2025-12-16 | [Voltar ao índice](#-índice)


### PR DESCRIPTION
## Descrição

Adiciona documentação completa para migração do Dialogflow CX para LangGraph e guia de variáveis de ambiente.

## Documentação Adicionada

### 📋 MIGRACAO_DIALOGFLOW_LANGGRAPH.md (581 linhas)
- Plano completo de migração Dialogflow CX → LangGraph 1.0.5
- Arquitetura dos workflows: analise_cpr e criar_cpr
- Mapeamento de modelos (OpenRouter free tier)
- Estratégia de human-in-the-loop com interrupts
- Plano de rollback e monitoramento
- Cronograma: 83% completo (Fases 1-4 concluídas)

### 📋 VARIAVEIS_AMBIENTE.md (376 linhas)
- Lista completa de variáveis para frontend (Vercel) e backend (Railway)
- Seções: Database, AI/LLM, Security, CORS, Observability
- Variáveis LangGraph: OPENROUTER_API_KEY, LANGGRAPH_CHECKPOINTER_URL
- Guias de configuração (Railway CLI, Vercel CLI)
- Checklists de deploy e troubleshooting

### 🔧 .gitignore
- Adicionado `.codex-git/` ao gitignore

## Contexto

Essa documentação suporta a implementação LangGraph que foi merged nas PRs #50, #51, #52 e #54 no backend. Documenta:
- Como os workflows substituem o Dialogflow CX
- Quais variáveis são necessárias em produção
- Como fazer deploy e rollback

## Referências Backend

- Backend PR #50: LangGraph implementation
- Backend PR #54: Environment setup validation
- Backend PR #51: Observability cleanup

## Checklist

- [x] Documentação clara e completa
- [x] Variáveis de ambiente documentadas
- [x] Guias de configuração para Railway/Vercel
- [x] Estratégia de migração documentada