### PR TITLE
fix: session rename now persists by refreshing list after update

### DIFF
--- a/src/components/v2/ConversationsSidebar.tsx
+++ b/src/components/v2/ConversationsSidebar.tsx
@@ -78,6 +78,14 @@ export function ConversationsSidebar({
   }, [fetchSessions, selectedProjectId])
 
   // Memoized handlers to prevent re-renders of child components
+  const handleUpdateSession = useCallback(
+    async (id: string, data: { title?: string }) => {
+      await updateSession(id, data)
+      fetchSessions(selectedProjectId).then(setSessions)
+    },
+    [updateSession, fetchSessions, selectedProjectId]
+  )
+
   const handleUpdateProject = useCallback(
     async (id: string, data: { title?: string }) => {
       await updateProject(id, data)
@@ -157,7 +165,7 @@ export function ConversationsSidebar({
             onSelectProject={setSelectedProjectId}
             sessionsLoading={sessionsLoading}
             projectsLoading={projectsLoading}
-            onUpdateSession={updateSession}
+            onUpdateSession={handleUpdateSession}
             onUpdateProject={handleUpdateProject}
             onDeleteSession={async (id) => {
               await deleteSession(id)
@@ -203,7 +211,7 @@ export function ConversationsSidebar({
           onSelectProject={setSelectedProjectId}
           sessionsLoading={sessionsLoading}
           projectsLoading={projectsLoading}
-          onUpdateSession={updateSession}
+          onUpdateSession={handleUpdateSession}
           onUpdateProject={handleUpdateProject}
           onDeleteSession={async (id) => {
             await deleteSession(id)


### PR DESCRIPTION
## Summary
- Fixes bug where renaming a conversation in the sidebar didn't persist visually after saving
- Created `handleUpdateSession` wrapper that refreshes the sessions list after updating the backend
- Applied fix to both overlay and normal sidebar modes

## Test plan
- [ ] Open sidebar and click edit icon on a conversation
- [ ] Change the name and press Enter or click outside
- [ ] Verify the new name persists in the list without needing to refresh the page