### PR TITLE
feat(analytics): add search and project selection tracking

### DIFF
--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -212,6 +212,15 @@ export function trackConversationSelected(
 }
 
 /**
+ * Track project selection
+ */
+export function trackProjectSelected(projectId: string): void {
+  track(ANALYTICS_EVENTS.PROJECT_SELECTED, {
+    project_id: projectId
+  })
+}
+
+/**
  * Track an error from Error Boundary
  */
 export function trackError(


### PR DESCRIPTION
## Summary

- Adiciona tracking de busca com debounce (1s de delay, mínimo 2 caracteres) no `ConversationsSidebar`
- Adiciona tracking de seleção de projeto quando usuário seleciona um projeto
- Adiciona função `trackProjectSelected()` ao módulo de analytics

## Eventos adicionados

| Evento | Propriedades | Trigger |
|--------|--------------|---------|
| `search_query_submitted` | `query`, `results_count` | Após 1s de inatividade na busca |
| `project_selected` | `project_id` | Ao clicar em um projeto |

## Arquivos modificados

- `src/components/v2/ConversationsSidebar.tsx` - Adiciona tracking hooks
- `src/lib/analytics/index.ts` - Adiciona função `trackProjectSelected()`

## Test plan

- [ ] Digitar na busca e verificar que evento `search_query_submitted` aparece no PostHog após 1s
- [ ] Verificar que buscas com menos de 2 caracteres NÃO disparam eventos
- [ ] Clicar em um projeto e verificar evento `project_selected` no PostHog
- [ ] Verificar que seleção de "Todas as Conversas" NÃO dispara evento (projectId é null)

## Related Issues

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)