### PR TITLE
fix(next15): move dynamic import with ssr:false to Client Component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata, Viewport } from 'next'
-import dynamic from 'next/dynamic'
 import {
   DM_Mono,
   Geist,
@@ -15,6 +14,7 @@ import { PostHogProvider } from '@/components/providers/PostHogProvider'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { InstallPrompt } from '@/components/v2/InstallPrompt'
 import { QueryProvider } from '@/providers/QueryProvider'
+import { WebVitalsReporterWrapper } from '@/components/v2/Monitoring/WebVitalsReporterWrapper'
 import './globals.css'
 
 const inter = Inter({
@@ -84,7 +84,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${inter.variable} ${playfair.variable} ${crimson.variable} ${geistSans.variable} ${dmMono.variable} font-sans antialiased bg-sand-100 text-verity-900 selection:bg-verity-200 selection:text-verity-900`}
+        className={`${inter.variable} ${playfair.variable} ${crimson.variable} ${geistSans.variable} ${dmMono.variable} bg-sand-100 font-sans text-verity-900 antialiased selection:bg-verity-200 selection:text-verity-900`}
       >
         <ThemeProvider
           attribute="class"
@@ -100,7 +100,7 @@ export default function RootLayout({
                 </ErrorBoundary>
                 <Toaster />
                 <InstallPrompt />
-                <WebVitalsReporter />
+                <WebVitalsReporterWrapper />
               </QueryProvider>
             </AuthProvider>
           </PostHogProvider>
@@ -109,9 +109,3 @@ export default function RootLayout({
     </html>
   )
 }
-
-// Dynamically import WebVitalsReporter to avoid SSR issues with client component
-const WebVitalsReporter = dynamic(
-  () => import('@/components/v2/Monitoring/WebVitalsReporter').then(m => m.WebVitalsReporter),
-  { ssr: false }
-)

--- a/src/components/v2/Monitoring/WebVitalsReporterWrapper.tsx
+++ b/src/components/v2/Monitoring/WebVitalsReporterWrapper.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+// Dynamic import with ssr: false must be in a Client Component
+const WebVitalsReporter = dynamic(
+  () => import('./WebVitalsReporter').then((m) => m.WebVitalsReporter),
+  { ssr: false }
+)
+
+export function WebVitalsReporterWrapper() {
+  return <WebVitalsReporter />
+}


### PR DESCRIPTION
## Summary

- Fix Next.js 15 error: `ssr: false` is not allowed with `next/dynamic` in Server Components
- Created `WebVitalsReporterWrapper` as a Client Component wrapper
- Updated `layout.tsx` to use the wrapper instead of direct dynamic import

## Problem

Next.js 15 enforces that `ssr: false` with `next/dynamic` can only be used in Client Components, not Server Components. The root `layout.tsx` is a Server Component by default.

## Solution

Moved the dynamic import logic to a dedicated Client Component (`WebVitalsReporterWrapper.tsx`).

## Test plan

- [x] Frontend loads without 500 error
- [x] Login page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)