### PR TITLE
fix: remove debug console.log statements

### DIFF
--- a/src/components/v2/ChatLayout.tsx
+++ b/src/components/v2/ChatLayout.tsx
@@ -243,19 +243,9 @@ export function ChatLayout({ sessionId }: ChatLayoutProps) {
                 setStagedFiles((prev) => prev.filter((f) => f.id !== id))
               }}
               onSessionCreated={(newSessionId) => {
-                console.log('[ChatLayout] Session created:', newSessionId)
                 router.push(`/chat/${newSessionId}`)
               }}
               onFileUploaded={(documentId, uploadedSessionId, fileInfo) => {
-                console.log(
-                  '[ChatLayout] File uploaded:',
-                  documentId,
-                  'to session:',
-                  uploadedSessionId,
-                  'file:',
-                  fileInfo
-                )
-
                 if (fileInfo) {
                   setStagedFiles((prev) => [
                     ...prev,

--- a/src/components/v2/FileUpload/FileUploadModal.tsx
+++ b/src/components/v2/FileUpload/FileUploadModal.tsx
@@ -142,8 +142,6 @@ export function FileUploadModal({
         // Se não tiver sessionId, criar uma nova sessão primeiro
         let uploadSessionId = sessionId
         if (!uploadSessionId) {
-          console.log('[FileUploadModal] No sessionId, creating new session...')
-          console.log('[FileUploadModal] No sessionId, creating new session...')
           const sessionResponse = await fetch('/api/sessions', {
             method: 'POST',
             headers: {
@@ -156,16 +154,11 @@ export function FileUploadModal({
           if (sessionResponse.ok) {
             const sessionData = await sessionResponse.json()
             uploadSessionId = sessionData.id
-            console.log('[FileUploadModal] Created session:', uploadSessionId)
 
             // Notify parent about new session
             if (onSessionCreated && uploadSessionId) {
               onSessionCreated(uploadSessionId)
             }
-          } else {
-            console.warn(
-              '[FileUploadModal] Failed to create session, upload will have no session'
-            )
           }
         }
 
@@ -178,11 +171,6 @@ export function FileUploadModal({
         formData.append('auto_process', 'true')
 
         // Use Next.js API Route as proxy to avoid CORS issues
-        console.log(
-          '[FileUploadModal] Uploading to proxy:',
-          '/api/documents/upload'
-        )
-
         const response = await fetch('/api/documents/upload', {
           method: 'POST',
           // headers, // No headers needed for FormData, browser sets boundary
@@ -420,7 +408,7 @@ export function FileUploadModal({
                   ? 'OK'
                   : 'Enviar'}
           </button>
-          
+
           {success && (
             <button
               onClick={handleAnalyze}


### PR DESCRIPTION
## Summary
Remove debug console.log statements that were leaking to production.

### Changes
- Remove 5 `console.log/warn` from `FileUploadModal.tsx`
- Remove 2 `console.log` from `ChatLayout.tsx`
- WebVitalsReporter logs kept (already conditional on NODE_ENV)

## Test plan
- [x] npm run lint passes
- [x] npm run build passes
- [ ] Manual test: file upload works without console spam

🤖 Generated with [Claude Code](https://claude.com/claude-code)