### PR TITLE
fix(a11y): add ARIA attributes to chat components

### DIFF
--- a/src/components/v2/ChatArea/ChatArea.tsx
+++ b/src/components/v2/ChatArea/ChatArea.tsx
@@ -134,6 +134,9 @@ export function ChatArea({ messages, isStreaming, onRefresh }: ChatAreaProps) {
               exit={{ opacity: 0 }}
               transition={{ duration: 0.3 }}
               className="space-y-6 pb-4 landscape:space-y-4"
+              role="log"
+              aria-label="Mensagens da conversa"
+              aria-live="polite"
             >
               {messages.map((message, index) => (
                 <MessageBubble

--- a/src/components/v2/ChatArea/MessageBubble.tsx
+++ b/src/components/v2/ChatArea/MessageBubble.tsx
@@ -47,7 +47,9 @@ export const MessageBubble = memo(function MessageBubble({
   }, [message.content])
 
   return (
-    <motion.div
+    <motion.article
+      role="article"
+      aria-label={isUser ? 'Sua mensagem' : 'Mensagem do assistente'}
       initial={{ opacity: 0, y: 16, scale: 0.95, rotateX: 5 }}
       animate={{ opacity: 1, y: 0, scale: 1, rotateX: 0 }}
       transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
@@ -248,6 +250,6 @@ export const MessageBubble = memo(function MessageBubble({
           )}
         </motion.div>
       </div>
-    </motion.div>
+    </motion.article>
   )
 })

--- a/src/components/v2/ChatArea/StreamingText.tsx
+++ b/src/components/v2/ChatArea/StreamingText.tsx
@@ -85,22 +85,28 @@ export function StreamingText({
 
   if (renderMarkdown) {
     return (
-      <div className={className}>
+      <div className={className} aria-live="polite" aria-atomic="false">
         <MarkdownRenderer classname="prose-sm prose-p:my-1 prose-headings:my-2 prose-ul:my-1 prose-ol:my-1 prose-hr:my-2 prose-hr:border-muted-foreground/20 max-w-none w-full [&_hr~p]:text-xs [&_hr~p]:opacity-70 [&_hr~p_strong]:text-xs [&_hr~p_strong]:font-medium">
           {displayedText}
         </MarkdownRenderer>
         {isStreaming && (
-          <span className="bg-gemini-blue ml-1 inline-block h-4 w-2 animate-pulse"></span>
+          <span
+            className="bg-gemini-blue ml-1 inline-block h-4 w-2 animate-pulse"
+            aria-hidden="true"
+          />
         )}
       </div>
     )
   }
 
   return (
-    <span className={className}>
+    <span className={className} aria-live="polite" aria-atomic="false">
       {displayedText}
       {isStreaming && (
-        <span className="bg-gemini-blue ml-1 inline-block h-4 w-2 animate-pulse"></span>
+        <span
+          className="bg-gemini-blue ml-1 inline-block h-4 w-2 animate-pulse"
+          aria-hidden="true"
+        />
       )}
     </span>
   )

--- a/src/components/v2/ChatArea/TypingIndicator.tsx
+++ b/src/components/v2/ChatArea/TypingIndicator.tsx
@@ -6,7 +6,12 @@ export function TypingIndicator() {
   const prefersReducedMotion = useReducedMotion()
 
   return (
-    <div className="flex w-full justify-start py-2">
+    <div
+      className="flex w-full justify-start py-2"
+      role="status"
+      aria-live="polite"
+      aria-label="O assistente está digitando"
+    >
       <div className="flex items-center gap-1.5 rounded-2xl rounded-tl-sm border-2 border-verity-100 bg-white px-4 py-3 shadow-[0_2px_8px_rgba(45,90,69,0.08)]">
         {[0, 1, 2].map((dot) => (
           <motion.div


### PR DESCRIPTION
## Summary
Improve screen reader experience for chat interface by adding proper ARIA attributes.

### Changes
- **TypingIndicator.tsx**: Add `role="status"`, `aria-live="polite"`, `aria-label`
- **StreamingText.tsx**: Add `aria-live="polite"`, `aria-atomic="false"`, hide cursor animation
- **ChatArea.tsx**: Add `role="log"`, `aria-label`, `aria-live` to message container
- **MessageBubble.tsx**: Change to `<article>` with dynamic `aria-label` based on sender

## Test plan
- [x] npm run lint passes
- [x] npm run build passes
- [ ] Test with VoiceOver (macOS) or NVDA (Windows)
- [ ] Verify typing indicator is announced
- [ ] Verify new messages are announced

🤖 Generated with [Claude Code](https://claude.com/claude-code)