### PR TITLE
feat(wizard): implement CPR Wizard Steps 1-3

### DIFF
--- a/src/components/v2/CPRWizard/CPRWizard.tsx
+++ b/src/components/v2/CPRWizard/CPRWizard.tsx
@@ -2,43 +2,13 @@
 
 import React, { useState, useEffect } from 'react'
 import { CPRWizardData } from './schema'
+import { StepProdutor } from './steps/StepProdutor'
+import { StepPropriedade } from './steps/StepPropriedade'
+import { StepCultura } from './steps/StepCultura'
 import { StepValues } from './steps/StepValues'
 import { StepGuarantees } from './steps/StepGuarantees'
 import { StepReview } from './steps/StepReview'
 import { cn } from '@/lib/utils'
-
-// =============================================================================
-// Placeholder Steps (1-3)
-// =============================================================================
-
-function PlaceholderStep({
-  title,
-  step,
-  onNext
-}: {
-  title: string
-  step: number
-  onNext: () => void
-}) {
-  return (
-    <div className="space-y-4 py-8 text-center animate-in fade-in">
-      <div className="text-sm uppercase tracking-wide text-muted-foreground">
-        Step {step} (Placeholder)
-      </div>
-      <h3 className="text-xl font-semibold">{title}</h3>
-      <p className="mx-auto max-w-md text-sm text-muted-foreground">
-        Este passo já foi implementado anteriormente ou é apenas ilustrativo
-        para este fluxo.
-      </p>
-      <button
-        onClick={onNext}
-        className="mt-6 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-      >
-        Simular Conclusão e Avançar
-      </button>
-    </div>
-  )
-}
 
 // =============================================================================
 // Main Component
@@ -153,24 +123,26 @@ export function CPRWizard() {
         ) : (
           <>
             {currentStep === 1 && (
-              <PlaceholderStep
-                title="Identificação do Produtor"
-                step={1}
+              <StepProdutor
+                data={data}
+                updateData={updateData}
                 onNext={next}
               />
             )}
             {currentStep === 2 && (
-              <PlaceholderStep
-                title="Seleção da Propriedade"
-                step={2}
+              <StepPropriedade
+                data={data}
+                updateData={updateData}
                 onNext={next}
+                onBack={back}
               />
             )}
             {currentStep === 3 && (
-              <PlaceholderStep
-                title="Definição da Cultura"
-                step={3}
+              <StepCultura
+                data={data}
+                updateData={updateData}
                 onNext={next}
+                onBack={back}
               />
             )}
 

--- a/src/components/v2/CPRWizard/schema.ts
+++ b/src/components/v2/CPRWizard/schema.ts
@@ -1,6 +1,49 @@
 import { z } from 'zod'
 
 // =============================================================================
+// Step 1: Produtor
+// =============================================================================
+
+export const stepProdutorSchema = z.object({
+  producerName: z.string().min(3, 'Nome deve ter no mínimo 3 caracteres'),
+  producerCpfCnpj: z
+    .string()
+    .min(11, 'CPF/CNPJ inválido')
+    .max(18, 'CPF/CNPJ inválido'),
+  producerPhone: z.string().min(10, 'Telefone inválido'),
+  producerEmail: z.string().email('Email inválido'),
+  producerAddress: z.string().min(10, 'Endereço deve ter no mínimo 10 caracteres')
+})
+
+// =============================================================================
+// Step 2: Propriedade
+// =============================================================================
+
+export const stepPropriedadeSchema = z.object({
+  farmName: z.string().min(3, 'Nome da propriedade deve ter no mínimo 3 caracteres'),
+  farmCar: z.string().optional(),
+  farmArea: z.number({ error: 'Área inválida' }).positive('Área deve ser positiva'),
+  farmState: z.string().min(2, 'Selecione o estado'),
+  farmCity: z.string().min(2, 'Cidade é obrigatória'),
+  farmAddress: z.string().min(10, 'Endereço da propriedade é obrigatório')
+})
+
+// =============================================================================
+// Step 3: Cultura
+// =============================================================================
+
+export const stepCulturaSchema = z.object({
+  commodity: z.string().min(1, 'Selecione a cultura'),
+  safra: z.string().min(1, 'Selecione a safra'),
+  expectedQuantity: z
+    .number({ error: 'Quantidade inválida' })
+    .positive('Quantidade deve ser positiva'),
+  unit: z.string().min(1, 'Selecione a unidade'),
+  plantingDate: z.string().optional(),
+  harvestDate: z.string().optional()
+})
+
+// =============================================================================
 // Step 4: Valores e Prazos
 // =============================================================================
 
@@ -70,16 +113,21 @@ export const stepGuaranteesSchema = z
 // =============================================================================
 
 export const cprWizardSchema = z.object({
-  // Steps 1-3 (Placeholders)
-  product: z.string().optional(),
-  producer: z.string().optional(),
-  farm: z.string().optional(),
+  // Step 1: Produtor
+  ...stepProdutorSchema.shape,
 
-  // Step 4
+  // Step 2: Propriedade
+  ...stepPropriedadeSchema.shape,
+
+  // Step 3: Cultura
+  ...stepCulturaSchema.shape,
+
+  // Step 4: Valores
   ...stepValuesSchema.shape,
 
-  // Step 5
+  // Step 5: Garantias
   ...stepGuaranteesSchema.shape
 })
 
 export type CPRWizardData = z.infer<typeof cprWizardSchema>
+

--- a/src/components/v2/CPRWizard/steps/StepCultura.tsx
+++ b/src/components/v2/CPRWizard/steps/StepCultura.tsx
@@ -1,0 +1,262 @@
+import React from 'react'
+import { CPRWizardData } from '../schema'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import { COMMODITY_INFO, type CommoditySymbol } from '@/lib/commodities'
+import { z } from 'zod'
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const SAFRAS = [
+  '2024/2025',
+  '2025/2026',
+  '2026/2027'
+]
+
+const UNITS = [
+  { value: 'kg', label: 'Quilogramas (kg)' },
+  { value: 'ton', label: 'Toneladas (ton)' },
+  { value: 'saca', label: 'Sacas (60kg)' },
+  { value: 'arroba', label: 'Arrobas (@)' }
+]
+
+// =============================================================================
+// Schema
+// =============================================================================
+
+export const stepCulturaSchema = z.object({
+  commodity: z.string().min(1, 'Selecione a cultura'),
+  safra: z.string().min(1, 'Selecione a safra'),
+  expectedQuantity: z
+    .number({ error: 'Quantidade inválida' })
+    .positive('Quantidade deve ser positiva'),
+  unit: z.string().min(1, 'Selecione a unidade'),
+  plantingDate: z.string().optional(),
+  harvestDate: z.string().optional()
+})
+
+export type StepCulturaData = z.infer<typeof stepCulturaSchema>
+
+// =============================================================================
+// Component
+// =============================================================================
+
+interface StepCulturaProps {
+  data: Partial<CPRWizardData>
+  updateData: (data: Partial<CPRWizardData>) => void
+  onNext: () => void
+  onBack: () => void
+}
+
+export function StepCultura({
+  data,
+  updateData,
+  onNext,
+  onBack
+}: StepCulturaProps) {
+  const [errors, setErrors] = React.useState<Record<string, string>>({})
+
+  // Get commodity options from COMMODITY_INFO
+  const commodityOptions = Object.entries(COMMODITY_INFO).map(([key, info]) => ({
+    value: key,
+    label: info.name
+  }))
+
+  const validate = () => {
+    try {
+      const toValidate = {
+        commodity: data.commodity || '',
+        safra: data.safra || '',
+        expectedQuantity: data.expectedQuantity,
+        unit: data.unit || '',
+        plantingDate: data.plantingDate || '',
+        harvestDate: data.harvestDate || ''
+      }
+
+      stepCulturaSchema.parse(toValidate)
+      setErrors({})
+      return true
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        const newErrors: Record<string, string> = {}
+        error.issues.forEach((err) => {
+          if (err.path[0]) newErrors[err.path[0] as string] = err.message
+        })
+        setErrors(newErrors)
+      }
+      return false
+    }
+  }
+
+  const handleNext = () => {
+    if (validate()) {
+      onNext()
+    }
+  }
+
+  // Get selected commodity info for display
+  const selectedCommodity = data.commodity
+    ? COMMODITY_INFO[data.commodity as CommoditySymbol]
+    : null
+
+  return (
+    <div className="space-y-6 duration-300 animate-in fade-in slide-in-from-right-4">
+      <div className="mb-4">
+        <h2 className="text-xl font-semibold">Definição da Cultura</h2>
+        <p className="text-sm text-muted-foreground">
+          Especifique a cultura e quantidade que será vinculada à CPR.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {/* Cultura */}
+        <div className="space-y-2">
+          <Label htmlFor="commodity">Cultura / Commodity</Label>
+          <Select
+            value={data.commodity}
+            onValueChange={(val) => updateData({ commodity: val })}
+          >
+            <SelectTrigger
+              id="commodity"
+              className={errors.commodity ? 'border-red-500' : ''}
+            >
+              <SelectValue placeholder="Selecione a cultura" />
+            </SelectTrigger>
+            <SelectContent>
+              {commodityOptions.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {errors.commodity && (
+            <span className="text-xs text-red-500">{errors.commodity}</span>
+          )}
+          {selectedCommodity && (
+            <span className="text-xs text-muted-foreground">
+              Símbolo: {selectedCommodity.symbol} | Moeda: {selectedCommodity.currency}
+            </span>
+          )}
+        </div>
+
+        {/* Safra */}
+        <div className="space-y-2">
+          <Label htmlFor="safra">Safra</Label>
+          <Select
+            value={data.safra}
+            onValueChange={(val) => updateData({ safra: val })}
+          >
+            <SelectTrigger
+              id="safra"
+              className={errors.safra ? 'border-red-500' : ''}
+            >
+              <SelectValue placeholder="Selecione a safra" />
+            </SelectTrigger>
+            <SelectContent>
+              {SAFRAS.map((safra) => (
+                <SelectItem key={safra} value={safra}>
+                  {safra}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {errors.safra && (
+            <span className="text-xs text-red-500">{errors.safra}</span>
+          )}
+        </div>
+
+        {/* Quantidade Prevista */}
+        <div className="space-y-2">
+          <Label htmlFor="expectedQuantity">Quantidade Prevista</Label>
+          <Input
+            id="expectedQuantity"
+            type="number"
+            min="0"
+            step="0.01"
+            placeholder="0.00"
+            value={data.expectedQuantity || ''}
+            onChange={(e) =>
+              updateData({ expectedQuantity: parseFloat(e.target.value) })
+            }
+            className={errors.expectedQuantity ? 'border-red-500' : ''}
+          />
+          {errors.expectedQuantity && (
+            <span className="text-xs text-red-500">{errors.expectedQuantity}</span>
+          )}
+        </div>
+
+        {/* Unidade */}
+        <div className="space-y-2">
+          <Label htmlFor="unit">Unidade</Label>
+          <Select
+            value={data.unit}
+            onValueChange={(val) => updateData({ unit: val })}
+          >
+            <SelectTrigger
+              id="unit"
+              className={errors.unit ? 'border-red-500' : ''}
+            >
+              <SelectValue placeholder="Selecione" />
+            </SelectTrigger>
+            <SelectContent>
+              {UNITS.map((unit) => (
+                <SelectItem key={unit.value} value={unit.value}>
+                  {unit.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {errors.unit && (
+            <span className="text-xs text-red-500">{errors.unit}</span>
+          )}
+        </div>
+
+        {/* Data de Plantio */}
+        <div className="space-y-2">
+          <Label htmlFor="plantingDate">
+            Data Prevista de Plantio{' '}
+            <span className="text-muted-foreground">(opcional)</span>
+          </Label>
+          <Input
+            id="plantingDate"
+            type="date"
+            value={data.plantingDate || ''}
+            onChange={(e) => updateData({ plantingDate: e.target.value })}
+          />
+        </div>
+
+        {/* Data de Colheita */}
+        <div className="space-y-2">
+          <Label htmlFor="harvestDate">
+            Data Prevista de Colheita{' '}
+            <span className="text-muted-foreground">(opcional)</span>
+          </Label>
+          <Input
+            id="harvestDate"
+            type="date"
+            value={data.harvestDate || ''}
+            onChange={(e) => updateData({ harvestDate: e.target.value })}
+          />
+        </div>
+      </div>
+
+      <div className="flex justify-between pt-4">
+        <Button variant="outline" onClick={onBack}>
+          Voltar
+        </Button>
+        <Button onClick={handleNext}>Próximo</Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/v2/CPRWizard/steps/StepProdutor.tsx
+++ b/src/components/v2/CPRWizard/steps/StepProdutor.tsx
@@ -1,0 +1,196 @@
+import React from 'react'
+import { CPRWizardData } from '../schema'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+import { z } from 'zod'
+
+// =============================================================================
+// Schema
+// =============================================================================
+
+export const stepProdutorSchema = z.object({
+  producerName: z.string().min(3, 'Nome deve ter no mínimo 3 caracteres'),
+  producerCpfCnpj: z
+    .string()
+    .min(11, 'CPF/CNPJ inválido')
+    .max(18, 'CPF/CNPJ inválido'),
+  producerPhone: z.string().min(10, 'Telefone inválido'),
+  producerEmail: z.string().email('Email inválido'),
+  producerAddress: z.string().min(10, 'Endereço deve ter no mínimo 10 caracteres')
+})
+
+export type StepProdutorData = z.infer<typeof stepProdutorSchema>
+
+// =============================================================================
+// Component
+// =============================================================================
+
+interface StepProdutorProps {
+  data: Partial<CPRWizardData>
+  updateData: (data: Partial<CPRWizardData>) => void
+  onNext: () => void
+}
+
+export function StepProdutor({ data, updateData, onNext }: StepProdutorProps) {
+  const [errors, setErrors] = React.useState<Record<string, string>>({})
+
+  const validate = () => {
+    try {
+      const toValidate = {
+        producerName: data.producerName || '',
+        producerCpfCnpj: data.producerCpfCnpj || '',
+        producerPhone: data.producerPhone || '',
+        producerEmail: data.producerEmail || '',
+        producerAddress: data.producerAddress || ''
+      }
+
+      stepProdutorSchema.parse(toValidate)
+      setErrors({})
+      return true
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        const newErrors: Record<string, string> = {}
+        error.issues.forEach((err) => {
+          if (err.path[0]) newErrors[err.path[0] as string] = err.message
+        })
+        setErrors(newErrors)
+      }
+      return false
+    }
+  }
+
+  const handleNext = () => {
+    if (validate()) {
+      onNext()
+    }
+  }
+
+  // CPF/CNPJ mask helper
+  const formatCpfCnpj = (value: string) => {
+    const digits = value.replace(/\D/g, '')
+    if (digits.length <= 11) {
+      // CPF: 000.000.000-00
+      return digits
+        .replace(/(\d{3})(\d)/, '$1.$2')
+        .replace(/(\d{3})(\d)/, '$1.$2')
+        .replace(/(\d{3})(\d{1,2})$/, '$1-$2')
+    } else {
+      // CNPJ: 00.000.000/0000-00
+      return digits
+        .replace(/^(\d{2})(\d)/, '$1.$2')
+        .replace(/^(\d{2})\.(\d{3})(\d)/, '$1.$2.$3')
+        .replace(/\.(\d{3})(\d)/, '.$1/$2')
+        .replace(/(\d{4})(\d)/, '$1-$2')
+        .slice(0, 18)
+    }
+  }
+
+  // Phone mask helper
+  const formatPhone = (value: string) => {
+    const digits = value.replace(/\D/g, '')
+    if (digits.length <= 10) {
+      return digits.replace(/(\d{2})(\d{4})(\d{0,4})/, '($1) $2-$3')
+    }
+    return digits.replace(/(\d{2})(\d{5})(\d{0,4})/, '($1) $2-$3')
+  }
+
+  return (
+    <div className="space-y-6 duration-300 animate-in fade-in slide-in-from-right-4">
+      <div className="mb-4">
+        <h2 className="text-xl font-semibold">Identificação do Produtor</h2>
+        <p className="text-sm text-muted-foreground">
+          Informe os dados do produtor rural que emitirá a CPR.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {/* Nome Completo */}
+        <div className="col-span-2 space-y-2">
+          <Label htmlFor="producerName">Nome Completo / Razão Social</Label>
+          <Input
+            id="producerName"
+            placeholder="Ex: João da Silva ou Fazenda Santa Maria Ltda"
+            value={data.producerName || ''}
+            onChange={(e) => updateData({ producerName: e.target.value })}
+            className={errors.producerName ? 'border-red-500' : ''}
+          />
+          {errors.producerName && (
+            <span className="text-xs text-red-500">{errors.producerName}</span>
+          )}
+        </div>
+
+        {/* CPF/CNPJ */}
+        <div className="space-y-2">
+          <Label htmlFor="producerCpfCnpj">CPF / CNPJ</Label>
+          <Input
+            id="producerCpfCnpj"
+            placeholder="000.000.000-00 ou 00.000.000/0000-00"
+            value={data.producerCpfCnpj || ''}
+            onChange={(e) =>
+              updateData({ producerCpfCnpj: formatCpfCnpj(e.target.value) })
+            }
+            className={errors.producerCpfCnpj ? 'border-red-500' : ''}
+            maxLength={18}
+          />
+          {errors.producerCpfCnpj && (
+            <span className="text-xs text-red-500">{errors.producerCpfCnpj}</span>
+          )}
+        </div>
+
+        {/* Telefone */}
+        <div className="space-y-2">
+          <Label htmlFor="producerPhone">Telefone</Label>
+          <Input
+            id="producerPhone"
+            placeholder="(00) 00000-0000"
+            value={data.producerPhone || ''}
+            onChange={(e) =>
+              updateData({ producerPhone: formatPhone(e.target.value) })
+            }
+            className={errors.producerPhone ? 'border-red-500' : ''}
+            maxLength={15}
+          />
+          {errors.producerPhone && (
+            <span className="text-xs text-red-500">{errors.producerPhone}</span>
+          )}
+        </div>
+
+        {/* Email */}
+        <div className="space-y-2">
+          <Label htmlFor="producerEmail">Email</Label>
+          <Input
+            id="producerEmail"
+            type="email"
+            placeholder="produtor@email.com"
+            value={data.producerEmail || ''}
+            onChange={(e) => updateData({ producerEmail: e.target.value })}
+            className={errors.producerEmail ? 'border-red-500' : ''}
+          />
+          {errors.producerEmail && (
+            <span className="text-xs text-red-500">{errors.producerEmail}</span>
+          )}
+        </div>
+
+        {/* Endereço Completo */}
+        <div className="col-span-2 space-y-2">
+          <Label htmlFor="producerAddress">Endereço Completo</Label>
+          <Input
+            id="producerAddress"
+            placeholder="Rua, número, bairro, cidade, estado, CEP"
+            value={data.producerAddress || ''}
+            onChange={(e) => updateData({ producerAddress: e.target.value })}
+            className={errors.producerAddress ? 'border-red-500' : ''}
+          />
+          {errors.producerAddress && (
+            <span className="text-xs text-red-500">{errors.producerAddress}</span>
+          )}
+        </div>
+      </div>
+
+      <div className="flex justify-end pt-4">
+        <Button onClick={handleNext}>Próximo</Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/v2/CPRWizard/steps/StepPropriedade.tsx
+++ b/src/components/v2/CPRWizard/steps/StepPropriedade.tsx
@@ -1,0 +1,224 @@
+import React from 'react'
+import { CPRWizardData } from '../schema'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import { z } from 'zod'
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const BRAZILIAN_STATES = [
+  'AC', 'AL', 'AP', 'AM', 'BA', 'CE', 'DF', 'ES', 'GO', 'MA',
+  'MT', 'MS', 'MG', 'PA', 'PB', 'PR', 'PE', 'PI', 'RJ', 'RN',
+  'RS', 'RO', 'RR', 'SC', 'SP', 'SE', 'TO'
+]
+
+// =============================================================================
+// Schema
+// =============================================================================
+
+export const stepPropriedadeSchema = z.object({
+  farmName: z.string().min(3, 'Nome da propriedade deve ter no mínimo 3 caracteres'),
+  farmCar: z
+    .string()
+    .regex(/^[A-Z]{2}-\d{7}-[A-Z0-9]{32}$|^.{15,}$/, 'CAR inválido ou incompleto')
+    .optional()
+    .or(z.literal('')),
+  farmArea: z.number({ error: 'Área inválida' }).positive('Área deve ser positiva'),
+  farmState: z.string().min(2, 'Selecione o estado'),
+  farmCity: z.string().min(2, 'Cidade é obrigatória'),
+  farmAddress: z.string().min(10, 'Endereço da propriedade é obrigatório')
+})
+
+export type StepPropriedadeData = z.infer<typeof stepPropriedadeSchema>
+
+// =============================================================================
+// Component
+// =============================================================================
+
+interface StepPropriedadeProps {
+  data: Partial<CPRWizardData>
+  updateData: (data: Partial<CPRWizardData>) => void
+  onNext: () => void
+  onBack: () => void
+}
+
+export function StepPropriedade({
+  data,
+  updateData,
+  onNext,
+  onBack
+}: StepPropriedadeProps) {
+  const [errors, setErrors] = React.useState<Record<string, string>>({})
+
+  const validate = () => {
+    try {
+      const toValidate = {
+        farmName: data.farmName || '',
+        farmCar: data.farmCar || '',
+        farmArea: data.farmArea,
+        farmState: data.farmState || '',
+        farmCity: data.farmCity || '',
+        farmAddress: data.farmAddress || ''
+      }
+
+      stepPropriedadeSchema.parse(toValidate)
+      setErrors({})
+      return true
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        const newErrors: Record<string, string> = {}
+        error.issues.forEach((err) => {
+          if (err.path[0]) newErrors[err.path[0] as string] = err.message
+        })
+        setErrors(newErrors)
+      }
+      return false
+    }
+  }
+
+  const handleNext = () => {
+    if (validate()) {
+      onNext()
+    }
+  }
+
+  return (
+    <div className="space-y-6 duration-300 animate-in fade-in slide-in-from-right-4">
+      <div className="mb-4">
+        <h2 className="text-xl font-semibold">Dados da Propriedade</h2>
+        <p className="text-sm text-muted-foreground">
+          Informe os dados da propriedade rural onde a produção será realizada.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {/* Nome da Propriedade */}
+        <div className="col-span-2 space-y-2">
+          <Label htmlFor="farmName">Nome da Propriedade</Label>
+          <Input
+            id="farmName"
+            placeholder="Ex: Fazenda Santa Maria"
+            value={data.farmName || ''}
+            onChange={(e) => updateData({ farmName: e.target.value })}
+            className={errors.farmName ? 'border-red-500' : ''}
+          />
+          {errors.farmName && (
+            <span className="text-xs text-red-500">{errors.farmName}</span>
+          )}
+        </div>
+
+        {/* CAR */}
+        <div className="col-span-2 space-y-2">
+          <Label htmlFor="farmCar">
+            CAR (Cadastro Ambiental Rural){' '}
+            <span className="text-muted-foreground">(opcional)</span>
+          </Label>
+          <Input
+            id="farmCar"
+            placeholder="UF-0000000-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+            value={data.farmCar || ''}
+            onChange={(e) => updateData({ farmCar: e.target.value.toUpperCase() })}
+            className={errors.farmCar ? 'border-red-500' : ''}
+          />
+          {errors.farmCar && (
+            <span className="text-xs text-red-500">{errors.farmCar}</span>
+          )}
+          <span className="text-xs text-muted-foreground">
+            Formato: UF-CÓDIGO IBGE-CÓDIGO CAR
+          </span>
+        </div>
+
+        {/* Área Total */}
+        <div className="space-y-2">
+          <Label htmlFor="farmArea">Área Total (ha)</Label>
+          <Input
+            id="farmArea"
+            type="number"
+            min="0"
+            step="0.01"
+            placeholder="0.00"
+            value={data.farmArea || ''}
+            onChange={(e) => updateData({ farmArea: parseFloat(e.target.value) })}
+            className={errors.farmArea ? 'border-red-500' : ''}
+          />
+          {errors.farmArea && (
+            <span className="text-xs text-red-500">{errors.farmArea}</span>
+          )}
+        </div>
+
+        {/* Estado */}
+        <div className="space-y-2">
+          <Label htmlFor="farmState">Estado</Label>
+          <Select
+            value={data.farmState}
+            onValueChange={(val) => updateData({ farmState: val })}
+          >
+            <SelectTrigger
+              id="farmState"
+              className={errors.farmState ? 'border-red-500' : ''}
+            >
+              <SelectValue placeholder="Selecione" />
+            </SelectTrigger>
+            <SelectContent>
+              {BRAZILIAN_STATES.map((state) => (
+                <SelectItem key={state} value={state}>
+                  {state}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {errors.farmState && (
+            <span className="text-xs text-red-500">{errors.farmState}</span>
+          )}
+        </div>
+
+        {/* Cidade */}
+        <div className="space-y-2">
+          <Label htmlFor="farmCity">Cidade</Label>
+          <Input
+            id="farmCity"
+            placeholder="Ex: Ribeirão Preto"
+            value={data.farmCity || ''}
+            onChange={(e) => updateData({ farmCity: e.target.value })}
+            className={errors.farmCity ? 'border-red-500' : ''}
+          />
+          {errors.farmCity && (
+            <span className="text-xs text-red-500">{errors.farmCity}</span>
+          )}
+        </div>
+
+        {/* Endereço */}
+        <div className="col-span-2 space-y-2">
+          <Label htmlFor="farmAddress">Endereço / Localização</Label>
+          <Input
+            id="farmAddress"
+            placeholder="Rodovia, km, coordenadas ou referência"
+            value={data.farmAddress || ''}
+            onChange={(e) => updateData({ farmAddress: e.target.value })}
+            className={errors.farmAddress ? 'border-red-500' : ''}
+          />
+          {errors.farmAddress && (
+            <span className="text-xs text-red-500">{errors.farmAddress}</span>
+          )}
+        </div>
+      </div>
+
+      <div className="flex justify-between pt-4">
+        <Button variant="outline" onClick={onBack}>
+          Voltar
+        </Button>
+        <Button onClick={handleNext}>Próximo</Button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Implements real form components for CPR Wizard Steps 1-3, replacing placeholders.

## New Components
- **StepProdutor.tsx** - Producer identification (name, CPF/CNPJ, phone, email, address) with input masking
- **StepPropriedade.tsx** - Farm data (name, CAR, area, state, city, address) with state dropdown
- **StepCultura.tsx** - Crop data (commodity, safra, quantity, unit, dates) with COMMODITY_INFO integration

## Changes
- Added Zod schemas for all new steps
- Updated combined schema in schema.ts
- Replaced PlaceholderStep calls with real components in CPRWizard.tsx

## Files Changed
- 3 new step components (750+ lines)
- Updated schema.ts with new field definitions
- Updated CPRWizard.tsx to use new components

## Testing
- Fill out all 6 wizard steps
- Verify form validation on each step
- Verify data persistence across steps